### PR TITLE
 重构菜单注入逻辑，避免系统更新导致API失效

### DIFF
--- a/src/patches/menuPatch.tsx
+++ b/src/patches/menuPatch.tsx
@@ -1,9 +1,4 @@
-import {
-  afterPatch,
-  findInReactTree,
-  getReactRoot,
-  type Patch,
-} from "@decky/ui";
+import { findInReactTree, getReactRoot } from "@decky/ui";
 import type { FC, ReactElement, ReactNode } from "react";
 import { FaMusic } from "react-icons/fa";
 export const ROUTE_PATH = "/decky-music";
@@ -76,8 +71,8 @@ const getReactTree = (): unknown => {
 const isMenuItemElement = (item: ReactMenuItem): boolean =>
   Boolean(
     item?.props?.label &&
-      item.props?.route &&
-      item.type &&
+      item?.props?.route &&
+      item?.type &&
       typeof item.type !== "string"
   );
 
@@ -87,7 +82,7 @@ const isMenuItemAlreadyAdded = (menuItems: ReactMenuItem[]): boolean =>
   );
 const getMenuItemIndexes = (items: ReactMenuItem[]): number[] =>
   items.flatMap((item, index) =>
-    item?.$$typeof && item.type !== "div" ? [index] : []
+    item?.$$typeof && item?.type !== "div" ? [index] : []
   );
 
 const getInsertIndex = (items: ReactMenuItem[]): number | null => {
@@ -105,13 +100,15 @@ const isPatchTarget = (value: unknown): value is PatchTarget =>
   isRecord(value) && typeof value.type === "function";
 const collectPatchTargets = (
   node: unknown,
-  targets: PatchTarget[] = []
+  targets: PatchTarget[] = [],
+  visited = new Set<unknown>()
 ): PatchTarget[] => {
-  if (!node || targets.length >= 12) {
+  if (!node || targets.length >= 12 || visited.has(node)) {
     return targets;
   }
+  visited.add(node);
   if (Array.isArray(node)) {
-    node.forEach((child) => collectPatchTargets(child, targets));
+    node.forEach((child) => collectPatchTargets(child, targets, visited));
     return targets;
   }
   if (!isRecord(node)) {
@@ -120,14 +117,14 @@ const collectPatchTargets = (
   if (isPatchTarget(node)) {
     targets.push(node);
   }
-  collectPatchTargets(node["props"], targets);
-  collectPatchTargets(node["children"], targets);
+  collectPatchTargets(node["props"], targets, visited);
+  collectPatchTargets(node["children"], targets, visited);
   return targets;
 };
 const getPatchTargets = (ret: MainMenuRenderElement): PatchTarget[] => {
   const legacyTarget = ret?.props?.children?.props?.children?.[0];
   const targets = collectPatchTargets(ret);
-  if (legacyTarget && !targets.includes(legacyTarget)) {
+  if (isPatchTarget(legacyTarget) && !targets.includes(legacyTarget)) {
     targets.unshift(legacyTarget);
   }
 
@@ -197,7 +194,6 @@ const doPatchMenu = (): (() => void) | null => {
     }
 
     const originalType = menuNode.return.type;
-    const innerPatches: Patch[] = [];
     const patchedComponents = new WeakMap<object, unknown>();
 
     const menuWrapper = (props: unknown): ReactElement => {
@@ -207,18 +203,23 @@ const doPatchMenu = (): (() => void) | null => {
           return;
         }
 
-        const originalComponent = target.type as unknown as object;
-        const patchedType = patchedComponents.get(originalComponent);
-        if (patchedType) {
-          target.type = patchedType;
-          return;
+        const originalFn = target.type;
+        const originalComponent = originalFn as unknown as object;
+        let patchedType = patchedComponents.get(originalComponent);
+        if (!patchedType) {
+          patchedType = function (
+            this: unknown,
+            ...args: unknown[]
+          ): unknown {
+            const innerRet = originalFn.apply(this, args);
+            return patchInnerMenu(innerRet);
+          };
+          patchedComponents.set(originalComponent, patchedType);
         }
 
-        const patch = afterPatch(target, "type", (_args, innerRet) =>
-          patchInnerMenu(innerRet)
-        );
-        patchedComponents.set(originalComponent, target.type);
-        innerPatches.push(patch);
+        if (typeof patchedType === "function") {
+          target.type = patchedType;
+        }
       });
       return ret;
     };
@@ -229,7 +230,6 @@ const doPatchMenu = (): (() => void) | null => {
     }
 
     return () => {
-      innerPatches.forEach((patch) => patch.unpatch());
       menuNode.return!.type = originalType;
       if (menuNode.return?.alternate) {
         menuNode.return.alternate.type = originalType;

--- a/src/patches/menuPatch.tsx
+++ b/src/patches/menuPatch.tsx
@@ -1,163 +1,251 @@
-import { Navigation } from "@decky/ui";
+import {
+  afterPatch,
+  findInReactTree,
+  getReactRoot,
+  type Patch,
+} from "@decky/ui";
+import type { FC, ReactElement, ReactNode } from "react";
+import { FaMusic } from "react-icons/fa";
 
 export const ROUTE_PATH = "/decky-music";
 
-const MENU_ENTRY_ATTR = "data-decky-music-menu-entry";
-const INSTALL_INTERVAL_MS = 1000;
+const MENU_ITEM_KEY = "decky-music";
+const PATCH_RETRY_INTERVAL_MS = 1000;
+const MENU_ITEM_LABEL = "音乐";
 
-type DeckyRuntimeGlobal = typeof globalThis & {
-  DFL?: {
-    getGamepadNavigationTrees?: () => Array<{
-      m_ID?: string;
-      Root?: {
-        Element?: HTMLElement;
+interface MainMenuItemProps {
+  route: string;
+  label: ReactNode;
+  active?: string;
+  onFocus?: () => void;
+  onGamepadFocus?: () => void;
+  icon?: ReactElement;
+  onActivate?: () => void;
+  children?: ReactNode;
+}
+interface MenuItemWrapperProps extends MainMenuItemProps {
+  MenuItemComponent: FC<MainMenuItemProps>;
+  useIconAsProp: boolean;
+}
+interface MainMenuRenderElement extends ReactElement {
+  props: {
+    children?: {
+      props?: {
+        children?: Array<{
+          type?: FC<MainMenuItemProps>;
+        }>;
       };
-    }>;
+    };
   };
-};
+}
+interface PatchTarget {
+  type?: unknown;
+  props?: unknown;
+}
+interface FiberNode {
+  memoizedProps?: {
+    navID?: string;
+  };
+  return?: {
+    type?: (props: unknown) => ReactElement;
+    alternate?: {
+      type?: (props: unknown) => ReactElement;
+    };
+  };
+}
 
+interface ReactMenuItem {
+  key?: string | null;
+  props?: Partial<MainMenuItemProps>;
+  type?: FC<MainMenuItemProps> | string;
+  $$typeof?: symbol;
+}
 let isPatched = false;
-let intervalTimerId: ReturnType<typeof setInterval> | null = null;
-
-const findMainMenuElement = (): HTMLElement | null => {
-  try {
-    const menuFromNavTree = (
-      globalThis as DeckyRuntimeGlobal
-    ).DFL?.getGamepadNavigationTrees?.().find((tree) => tree?.m_ID === "MainNavMenuContainer")?.Root
-      ?.Element;
-
-    if (menuFromNavTree) {
-      return menuFromNavTree;
-    }
-  } catch {
-    // Fall back to the DOM lookup below.
+let unpatchFn: (() => void) | null = null;
+let retryTimerId: ReturnType<typeof setTimeout> | null = null;
+const canUseDocument = (): boolean => typeof document !== "undefined";
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+const getReactTree = (): unknown => {
+  if (!canUseDocument()) {
+    return null;
   }
 
-  return document.getElementById("MainNavMenuContainer");
+  const rootElement = document.getElementById("root");
+  return rootElement ? getReactRoot(rootElement) : null;
 };
 
-const navigateToMusic = (event?: Event) => {
-  event?.preventDefault();
-  event?.stopPropagation();
-
-  try {
-    Navigation.Navigate(ROUTE_PATH);
-  } catch {
-    // Steam may rebuild the menu while the click is being handled.
-  }
-};
-
-const replaceIcon = (menuItem: Element) => {
-  const oldIcon = menuItem.querySelector("svg");
-  if (!oldIcon) {
-    return;
-  }
-
-  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-  svg.setAttribute("viewBox", "0 0 512 512");
-  svg.setAttribute("fill", "none");
-
-  const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
-  path.setAttribute("fill", "currentColor");
-  path.setAttribute(
-    "d",
-    "M470.38 1.51L150.41 96A32 32 0 0 0 128 126.51v261.41A139 139 0 0 0 96 384c-53 0-96 28.66-96 64s43 64 96 64 96-28.66 96-64V214.32l256-75v184.61a138.4 138.4 0 0 0-32-3.93c-53 0-96 28.66-96 64s43 64 96 64 96-28.65 96-64V32a32 32 0 0 0-41.62-30.49z"
+const isMenuItemElement = (item: ReactMenuItem): boolean =>
+  Boolean(
+    item?.props?.label &&
+      item.props.route &&
+      item.type &&
+      typeof item.type !== "string"
   );
 
-  svg.appendChild(path);
-  oldIcon.replaceWith(svg);
-};
-
-const stripFocusState = (entry: Element) => {
-  entry.querySelectorAll("*").forEach((element) => {
-    element.classList.remove("gpfocus", "gpfocuswithin");
-  });
-};
-
-const findMenuItemByLabels = (menuItems: Element[], labels: string[]) =>
-  menuItems.find((item) => {
-    const ariaLabel = item.getAttribute("aria-label")?.trim().toLocaleLowerCase();
-    return ariaLabel ? labels.includes(ariaLabel) : false;
-  }) || null;
-
-const findLeafTextElement = (menuItem: Element, originalLabel: string | null) => {
-  const candidates = Array.from(menuItem.querySelectorAll("div")).reverse();
-
-  if (originalLabel) {
-    const exactMatch = candidates.find((element) => element.textContent?.trim() === originalLabel);
-    if (exactMatch) {
-      return exactMatch;
-    }
-  }
-
-  return (
-    candidates.find(
-      (element) =>
-        element.children.length === 0 &&
-        Boolean(element.textContent?.trim()) &&
-        !element.querySelector("svg")
-    ) || null
+const isMenuItemAlreadyAdded = (menuItems: ReactMenuItem[]): boolean =>
+  menuItems.some(
+    (item) => item?.props?.route === ROUTE_PATH || item?.key === MENU_ITEM_KEY
   );
-};
 
-const setEntryLabel = (menuItem: Element, originalLabel: string | null) => {
-  menuItem.setAttribute("aria-label", "\u97f3\u4e50");
-  menuItem.setAttribute("tabindex", "0");
-  menuItem.removeAttribute("data-gp-focus");
-  menuItem.removeAttribute("data-gp-focus-visible");
+const getMenuItemIndexes = (items: ReactMenuItem[]): number[] =>
+  items.flatMap((item, index) =>
+    item?.$$typeof && item.type !== "div" ? [index] : []
+  );
 
-  const labelElement = findLeafTextElement(menuItem, originalLabel);
-  if (labelElement) {
-    labelElement.textContent = "\u97f3\u4e50";
+const getInsertIndex = (items: ReactMenuItem[]): number | null => {
+  const itemIndexes = getMenuItemIndexes(items);
+  if (itemIndexes.length === 0) {
+    return null;
   }
+
+  return itemIndexes.length > 4
+    ? itemIndexes[3] + 1
+    : itemIndexes[itemIndexes.length - 1] + 1;
 };
 
-const bindNavigation = (menuItem: Element) => {
-  menuItem.addEventListener("click", navigateToMusic, true);
-  menuItem.addEventListener("mouseup", navigateToMusic, true);
-  menuItem.addEventListener(
-    "keydown",
-    (event) => {
-      const keyboardEvent = event as KeyboardEvent;
-      if (keyboardEvent.key === "Enter" || keyboardEvent.key === " ") {
-        navigateToMusic(event);
+const isPatchTarget = (value: unknown): value is PatchTarget =>
+  isRecord(value) && typeof value.type === "function";
+
+const collectPatchTargets = (
+  node: unknown,
+  targets: PatchTarget[] = []
+): PatchTarget[] => {
+  if (!node || targets.length >= 12) {
+    return targets;
+  }
+
+  if (Array.isArray(node)) {
+    node.forEach((child) => collectPatchTargets(child, targets));
+    return targets;
+  }
+
+  if (!isRecord(node)) {
+    return targets;
+  }
+
+  if (isPatchTarget(node)) {
+    targets.push(node);
+  }
+
+  collectPatchTargets(node.props, targets);
+  collectPatchTargets(node.children, targets);
+  return targets;
+};
+
+const getPatchTargets = (ret: MainMenuRenderElement): PatchTarget[] => {
+  const legacyTarget = ret?.props?.children?.props?.children?.[0];
+  const targets = collectPatchTargets(ret);
+  if (legacyTarget && !targets.includes(legacyTarget)) {
+    targets.unshift(legacyTarget);
+  }
+
+  return targets.filter(isPatchTarget);
+};
+
+const MenuItemWrapper: FC<MenuItemWrapperProps> = ({
+  MenuItemComponent,
+  label,
+  useIconAsProp,
+  ...props
+}) => {
+  const iconProps = useIconAsProp
+    ? { icon: <FaMusic /> }
+    : { children: <FaMusic /> };
+
+  return <MenuItemComponent {...props} {...iconProps} label={label} />;
+};
+
+const patchInnerMenu = (innerRet: unknown): unknown => {
+  const menuItems = findInReactTree(
+    innerRet,
+    (node: unknown) =>
+      Array.isArray(node) && node.some((item) => isMenuItemElement(item))
+  ) as ReactMenuItem[] | null;
+
+  if (!menuItems || isMenuItemAlreadyAdded(menuItems)) {
+    return innerRet;
+  }
+
+  const templateItem = menuItems.find(isMenuItemElement);
+  if (!templateItem?.props || typeof templateItem.type === "string") {
+    return innerRet;
+  }
+
+  const insertIndex = getInsertIndex(menuItems);
+  if (insertIndex === null) {
+    return innerRet;
+  }
+
+  const newItem = (
+    <MenuItemWrapper
+      key={MENU_ITEM_KEY}
+      route={ROUTE_PATH}
+      active="if-within-route"
+      label={MENU_ITEM_LABEL}
+      onFocus={templateItem.props.onFocus}
+      onGamepadFocus={templateItem.props.onGamepadFocus}
+      useIconAsProp={Boolean(templateItem.props.icon)}
+      MenuItemComponent={templateItem.type as FC<MainMenuItemProps>}
+    />
+  );
+
+  menuItems.splice(insertIndex, 0, newItem);
+  return innerRet;
+};
+
+const doPatchMenu = (): (() => void) | null => {
+  try {
+    const menuNode = findInReactTree(
+      getReactTree(),
+      (node: FiberNode) => node?.memoizedProps?.navID === "MainNavMenuContainer"
+    ) as FiberNode | null;
+
+    if (!menuNode?.return?.type) {
+      return null;
+    }
+
+    const originalType = menuNode.return.type;
+    const innerPatches: Patch[] = [];
+
+    const menuWrapper = (props: unknown): ReactElement => {
+      const ret = originalType(props) as MainMenuRenderElement;
+      getPatchTargets(ret).forEach((target) => {
+        const patch = afterPatch(target, "type", (_args, innerRet) =>
+          patchInnerMenu(innerRet)
+        );
+        innerPatches.push(patch);
+      });
+      return ret;
+    };
+
+    menuNode.return.type = menuWrapper;
+    if (menuNode.return.alternate) {
+      menuNode.return.alternate.type = menuWrapper;
+    }
+
+    return () => {
+      innerPatches.forEach((patch) => {
+        if (!patch.hasUnpatched) {
+          patch.unpatch();
+        }
+      });
+      menuNode.return!.type = originalType;
+      if (menuNode.return?.alternate) {
+        menuNode.return.alternate.type = originalType;
       }
-    },
-    true
-  );
+    };
+  } catch (error) {
+    console.error("[Decky Music] Failed to patch main menu:", error);
+    return null;
+  }
 };
 
-const installMenuEntryOnce = () => {
-  const mainMenu = findMainMenuElement();
-  if (!mainMenu || mainMenu.querySelector(`[${MENU_ENTRY_ATTR}]`)) {
-    return;
-  }
-
-  const menuItems = Array.from(mainMenu.querySelectorAll('[role="menuitem"]'));
-  const settingsItem =
-    findMenuItemByLabels(menuItems, ["settings", "\u8bbe\u7f6e"]) ||
-    menuItems[menuItems.length - 2] ||
-    null;
-  const settingsRow = settingsItem?.parentElement;
-  if (!settingsItem || !settingsRow?.parentElement) {
-    return;
-  }
-
-  const mediaItem =
-    findMenuItemByLabels(menuItems, ["media", "\u5a92\u4f53"]) || menuItems[4] || null;
-  const insertBeforeRow = mediaItem?.parentElement || settingsRow;
-  const originalLabel = settingsItem.getAttribute("aria-label")?.trim() || null;
-
-  const entry = settingsRow.cloneNode(true) as Element;
-  entry.setAttribute(MENU_ENTRY_ATTR, "true");
-  stripFocusState(entry);
-
-  const menuItem = entry.querySelector('[role="menuitem"]') || entry;
-  setEntryLabel(menuItem, originalLabel);
-  replaceIcon(menuItem);
-  bindNavigation(menuItem);
-
-  insertBeforeRow.parentElement?.insertBefore(entry, insertBeforeRow);
+const scheduleRetry = (): void => {
+  retryTimerId = setTimeout(() => {
+    retryTimerId = null;
+    menuManager.enable();
+  }, PATCH_RETRY_INTERVAL_MS);
 };
 
 export const menuManager = {
@@ -166,25 +254,34 @@ export const menuManager = {
       return;
     }
 
-    installMenuEntryOnce();
-    intervalTimerId = setInterval(installMenuEntryOnce, INSTALL_INTERVAL_MS);
+    const restore = doPatchMenu();
+    if (!restore) {
+      return;
+    }
+
+    unpatchFn = restore;
     isPatched = true;
   },
 
   enable: () => {
+    if (isPatched || retryTimerId) {
+      return;
+    }
+
     menuManager.tryEnable();
+    if (!isPatched && canUseDocument()) {
+      scheduleRetry();
+    }
   },
 
   disable: () => {
-    if (intervalTimerId) {
-      clearInterval(intervalTimerId);
-      intervalTimerId = null;
+    if (retryTimerId) {
+      clearTimeout(retryTimerId);
+      retryTimerId = null;
     }
 
-    findMainMenuElement()
-      ?.querySelectorAll(`[${MENU_ENTRY_ATTR}]`)
-      .forEach((entry) => entry.remove());
-
+    unpatchFn?.();
+    unpatchFn = null;
     isPatched = false;
   },
 

--- a/src/patches/menuPatch.tsx
+++ b/src/patches/menuPatch.tsx
@@ -74,20 +74,41 @@ const stripFocusState = (entry: Element) => {
   });
 };
 
-const setEntryLabel = (menuItem: Element) => {
+const findMenuItemByLabels = (menuItems: Element[], labels: string[]) =>
+  menuItems.find((item) => {
+    const ariaLabel = item.getAttribute("aria-label")?.trim().toLocaleLowerCase();
+    return ariaLabel ? labels.includes(ariaLabel) : false;
+  }) || null;
+
+const findLeafTextElement = (menuItem: Element, originalLabel: string | null) => {
+  const candidates = Array.from(menuItem.querySelectorAll("div")).reverse();
+
+  if (originalLabel) {
+    const exactMatch = candidates.find((element) => element.textContent?.trim() === originalLabel);
+    if (exactMatch) {
+      return exactMatch;
+    }
+  }
+
+  return (
+    candidates.find(
+      (element) =>
+        element.children.length === 0 &&
+        Boolean(element.textContent?.trim()) &&
+        !element.querySelector("svg")
+    ) || null
+  );
+};
+
+const setEntryLabel = (menuItem: Element, originalLabel: string | null) => {
   menuItem.setAttribute("aria-label", "\u97f3\u4e50");
   menuItem.setAttribute("tabindex", "0");
   menuItem.removeAttribute("data-gp-focus");
   menuItem.removeAttribute("data-gp-focus-visible");
 
-  const labelElement = Array.from(menuItem.querySelectorAll("div"))
-    .reverse()
-    .find((element) => element.textContent?.trim() === "\u8bbe\u7f6e");
-
+  const labelElement = findLeafTextElement(menuItem, originalLabel);
   if (labelElement) {
     labelElement.textContent = "\u97f3\u4e50";
-  } else {
-    menuItem.textContent = "\u97f3\u4e50";
   }
 };
 
@@ -112,21 +133,27 @@ const installMenuEntryOnce = () => {
     return;
   }
 
-  const settingsItem = mainMenu.querySelector('[role="menuitem"][aria-label="\u8bbe\u7f6e"]');
+  const menuItems = Array.from(mainMenu.querySelectorAll('[role="menuitem"]'));
+  const settingsItem =
+    findMenuItemByLabels(menuItems, ["settings", "\u8bbe\u7f6e"]) ||
+    menuItems[menuItems.length - 2] ||
+    null;
   const settingsRow = settingsItem?.parentElement;
   if (!settingsItem || !settingsRow?.parentElement) {
     return;
   }
 
-  const mediaItem = mainMenu.querySelector('[role="menuitem"][aria-label="\u5a92\u4f53"]');
+  const mediaItem =
+    findMenuItemByLabels(menuItems, ["media", "\u5a92\u4f53"]) || menuItems[4] || null;
   const insertBeforeRow = mediaItem?.parentElement || settingsRow;
+  const originalLabel = settingsItem.getAttribute("aria-label")?.trim() || null;
 
   const entry = settingsRow.cloneNode(true) as Element;
   entry.setAttribute(MENU_ENTRY_ATTR, "true");
   stripFocusState(entry);
 
   const menuItem = entry.querySelector('[role="menuitem"]') || entry;
-  setEntryLabel(menuItem);
+  setEntryLabel(menuItem, originalLabel);
   replaceIcon(menuItem);
   bindNavigation(menuItem);
 

--- a/src/patches/menuPatch.tsx
+++ b/src/patches/menuPatch.tsx
@@ -1,58 +1,25 @@
 import { findInReactTree, getReactRoot } from "@decky/ui";
-import type { FC, ReactElement, ReactNode } from "react";
+import type { FC, ReactElement } from "react";
 import { FaMusic } from "react-icons/fa";
+import {
+  invokeOriginalComponent,
+  patchRenderedMenu,
+  renderComponent,
+} from "./menuPatchRuntime";
+import type {
+  FiberNode,
+  MainMenuItemProps,
+  MainMenuRenderElement,
+  MenuItemWrapperProps,
+  PatchTarget,
+  ReactMenuItem,
+} from "./menuPatchTypes";
+
 export const ROUTE_PATH = "/decky-music";
 const MENU_ITEM_KEY = "decky-music";
 const PATCH_RETRY_INTERVAL_MS = 1000;
 const MENU_ITEM_LABEL = "音乐";
 
-interface MainMenuItemProps {
-  route: string;
-  label: ReactNode;
-  active?: string;
-  onFocus?: () => void;
-  onGamepadFocus?: () => void;
-  icon?: ReactElement;
-  onActivate?: () => void;
-  children?: ReactNode;
-}
-interface MenuItemWrapperProps extends MainMenuItemProps {
-  MenuItemComponent: FC<MainMenuItemProps>;
-  useIconAsProp: boolean;
-}
-interface MainMenuRenderElement extends ReactElement {
-  props: {
-    children?: {
-      props?: {
-        children?: Array<{
-          type?: FC<MainMenuItemProps>;
-        }>;
-      };
-    };
-  };
-}
-interface PatchTarget {
-  type?: unknown;
-  props?: unknown;
-}
-interface FiberNode {
-  memoizedProps?: {
-    navID?: string;
-  };
-  return?: {
-    type?: (props: unknown) => ReactElement;
-    alternate?: {
-      type?: (props: unknown) => ReactElement;
-    };
-  };
-}
-
-interface ReactMenuItem {
-  key?: string | null;
-  props?: Partial<MainMenuItemProps>;
-  type?: FC<MainMenuItemProps> | string;
-  $$typeof?: symbol;
-}
 let isPatched = false;
 let unpatchFn: (() => void) | null = null;
 let retryTimerId: ReturnType<typeof setTimeout> | null = null;
@@ -197,13 +164,20 @@ const doPatchMenu = (): (() => void) | null => {
     const patchedComponents = new WeakMap<object, unknown>();
 
     const menuWrapper = (props: unknown): ReactElement => {
-      const ret = originalType(props) as MainMenuRenderElement;
+      const ret = renderComponent(
+        originalType,
+        props
+      ) as MainMenuRenderElement | null;
+      if (!ret) {
+        return null as unknown as ReactElement;
+      }
+
       getPatchTargets(ret).forEach((target) => {
         if (typeof target.type !== "function") {
           return;
         }
 
-        const originalFn = target.type;
+        const originalFn = target.type as (...args: unknown[]) => unknown;
         const originalComponent = originalFn as unknown as object;
         let patchedType = patchedComponents.get(originalComponent);
         if (!patchedType) {
@@ -211,8 +185,8 @@ const doPatchMenu = (): (() => void) | null => {
             this: unknown,
             ...args: unknown[]
           ): unknown {
-            const innerRet = originalFn.apply(this, args);
-            return patchInnerMenu(innerRet);
+            const innerRet = invokeOriginalComponent(originalFn, this, args);
+            return patchRenderedMenu(innerRet, patchInnerMenu);
           };
           patchedComponents.set(originalComponent, patchedType);
         }
@@ -230,9 +204,11 @@ const doPatchMenu = (): (() => void) | null => {
     }
 
     return () => {
-      menuNode.return!.type = originalType;
-      if (menuNode.return?.alternate) {
-        menuNode.return.alternate.type = originalType;
+      if (menuNode?.return) {
+        menuNode.return.type = originalType;
+        if (menuNode.return.alternate) {
+          menuNode.return.alternate.type = originalType;
+        }
       }
     };
   } catch (error) {

--- a/src/patches/menuPatch.tsx
+++ b/src/patches/menuPatch.tsx
@@ -6,9 +6,7 @@ import {
 } from "@decky/ui";
 import type { FC, ReactElement, ReactNode } from "react";
 import { FaMusic } from "react-icons/fa";
-
 export const ROUTE_PATH = "/decky-music";
-
 const MENU_ITEM_KEY = "decky-music";
 const PATCH_RETRY_INTERVAL_MS = 1000;
 const MENU_ITEM_LABEL = "音乐";
@@ -78,7 +76,7 @@ const getReactTree = (): unknown => {
 const isMenuItemElement = (item: ReactMenuItem): boolean =>
   Boolean(
     item?.props?.label &&
-      item.props.route &&
+      item.props?.route &&
       item.type &&
       typeof item.type !== "string"
   );
@@ -87,7 +85,6 @@ const isMenuItemAlreadyAdded = (menuItems: ReactMenuItem[]): boolean =>
   menuItems.some(
     (item) => item?.props?.route === ROUTE_PATH || item?.key === MENU_ITEM_KEY
   );
-
 const getMenuItemIndexes = (items: ReactMenuItem[]): number[] =>
   items.flatMap((item, index) =>
     item?.$$typeof && item.type !== "div" ? [index] : []
@@ -106,7 +103,6 @@ const getInsertIndex = (items: ReactMenuItem[]): number | null => {
 
 const isPatchTarget = (value: unknown): value is PatchTarget =>
   isRecord(value) && typeof value.type === "function";
-
 const collectPatchTargets = (
   node: unknown,
   targets: PatchTarget[] = []
@@ -114,25 +110,20 @@ const collectPatchTargets = (
   if (!node || targets.length >= 12) {
     return targets;
   }
-
   if (Array.isArray(node)) {
     node.forEach((child) => collectPatchTargets(child, targets));
     return targets;
   }
-
   if (!isRecord(node)) {
     return targets;
   }
-
   if (isPatchTarget(node)) {
     targets.push(node);
   }
-
-  collectPatchTargets(node.props, targets);
-  collectPatchTargets(node.children, targets);
+  collectPatchTargets(node["props"], targets);
+  collectPatchTargets(node["children"], targets);
   return targets;
 };
-
 const getPatchTargets = (ret: MainMenuRenderElement): PatchTarget[] => {
   const legacyTarget = ret?.props?.children?.props?.children?.[0];
   const targets = collectPatchTargets(ret);
@@ -207,13 +198,26 @@ const doPatchMenu = (): (() => void) | null => {
 
     const originalType = menuNode.return.type;
     const innerPatches: Patch[] = [];
+    const patchedComponents = new WeakMap<object, unknown>();
 
     const menuWrapper = (props: unknown): ReactElement => {
       const ret = originalType(props) as MainMenuRenderElement;
       getPatchTargets(ret).forEach((target) => {
+        if (typeof target.type !== "function") {
+          return;
+        }
+
+        const originalComponent = target.type as unknown as object;
+        const patchedType = patchedComponents.get(originalComponent);
+        if (patchedType) {
+          target.type = patchedType;
+          return;
+        }
+
         const patch = afterPatch(target, "type", (_args, innerRet) =>
           patchInnerMenu(innerRet)
         );
+        patchedComponents.set(originalComponent, target.type);
         innerPatches.push(patch);
       });
       return ret;
@@ -225,11 +229,7 @@ const doPatchMenu = (): (() => void) | null => {
     }
 
     return () => {
-      innerPatches.forEach((patch) => {
-        if (!patch.hasUnpatched) {
-          patch.unpatch();
-        }
-      });
+      innerPatches.forEach((patch) => patch.unpatch());
       menuNode.return!.type = originalType;
       if (menuNode.return?.alternate) {
         menuNode.return.alternate.type = originalType;

--- a/src/patches/menuPatch.tsx
+++ b/src/patches/menuPatch.tsx
@@ -1,249 +1,173 @@
-/**
- * 左侧主菜单注入 Patch
- * 参考 DeckWebBrowser 实现，使用新版 @decky/ui API
- */
-/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Navigation } from "@decky/ui";
 
-import { FC, ReactElement, ReactNode } from "react";
-import { afterPatch, findInReactTree, getReactRoot } from "@decky/ui";
-import { FaMusic } from "react-icons/fa";
-
-// 路由路径
 export const ROUTE_PATH = "/decky-music";
 
-// 菜单项的 Props 接口
-interface MainMenuItemProps {
-  route: string;
-  label: ReactNode;
-  onFocus: () => void;
-  icon?: ReactElement;
-  onActivate?: () => void;
-  children?: ReactNode;
-}
+const MENU_ENTRY_ATTR = "data-decky-music-menu-entry";
+const INSTALL_INTERVAL_MS = 1000;
 
-// 获取 React 树
-// eslint-disable-next-line no-undef
-const getReactTree = () => getReactRoot(document.getElementById('root') as HTMLElement);
-
-// 辅助函数：检查是否为菜单项元素
-const isMenuItemElement = (e: any): boolean =>
-  Boolean(e?.props?.label && e?.props?.onFocus && e?.props?.route && e?.type?.toString);
-
-// 辅助函数：检查菜单项是否已存在
-const isMenuItemAlreadyAdded = (menuItems: any[]): boolean =>
-  menuItems.some((item: any) => item?.props?.route === ROUTE_PATH || item?.key === 'decky-music');
-
-// 菜单项包装组件
-interface MenuItemWrapperProps extends MainMenuItemProps {
-  MenuItemComponent: FC<MainMenuItemProps>;
-  useIconAsProp: boolean;
-}
-
-const MenuItemWrapper: FC<MenuItemWrapperProps> = ({ 
-  MenuItemComponent, 
-  label, 
-  useIconAsProp, 
-  ...props 
-}) => {
-  const iconProps = useIconAsProp 
-    ? { icon: <FaMusic /> } 
-    : { children: <FaMusic /> };
-
-  return (
-    <MenuItemComponent
-      {...props}
-      {...iconProps}
-      label={label}
-    />
-  );
+type DeckyRuntimeGlobal = typeof globalThis & {
+  DFL?: {
+    getGamepadNavigationTrees?: () => Array<{
+      m_ID?: string;
+      Root?: {
+        Element?: HTMLElement;
+      };
+    }>;
+  };
 };
 
-// 全局状态
 let isPatched = false;
-let unpatchFn: (() => void) | null = null;
-let retryTimerId: ReturnType<typeof setTimeout> | null = null;
-const PATCH_RETRY_INTERVAL_MS = 1000;
+let intervalTimerId: ReturnType<typeof setInterval> | null = null;
 
-// Patch 主菜单
-const doPatchMenu = (): (() => void) | null => {
+const findMainMenuElement = (): HTMLElement | null => {
   try {
-    const menuNode = findInReactTree(
-      getReactTree(), 
-      (node: any) => node?.memoizedProps?.navID === 'MainNavMenuContainer'
-    );
+    const menuFromNavTree = (
+      globalThis as DeckyRuntimeGlobal
+    ).DFL?.getGamepadNavigationTrees?.().find((tree) => tree?.m_ID === "MainNavMenuContainer")?.Root
+      ?.Element;
 
-    if (!menuNode || !menuNode.return?.type) {
-      return null;
+    if (menuFromNavTree) {
+      return menuFromNavTree;
     }
-
-    const orig = menuNode.return.type;
-    let patchedInnerMenu: any;
-
-    const menuWrapper = (props: any) => {
-      const ret = orig(props);
-      
-      if (!ret?.props?.children?.props?.children?.[0]?.type) {
-        return ret;
-      }
-
-      if (patchedInnerMenu) {
-        ret.props.children.props.children[0].type = patchedInnerMenu;
-      } else {
-        afterPatch(ret.props.children.props.children[0], 'type', (_: any, innerRet: any) => {
-          const menuItems = findInReactTree(
-            innerRet, 
-            (node: any) => Array.isArray(node) && node.some(isMenuItemElement)
-          ) as any[] | null;
-
-          if (!menuItems) {
-            return innerRet;
-          }
-
-          // 检查是否已经添加过
-          if (isMenuItemAlreadyAdded(menuItems)) {
-            return innerRet;
-          }
-
-          // 找到一个现有菜单项作为参考
-          const menuItem = menuItems.find(isMenuItemElement) as { 
-            props: MainMenuItemProps; 
-            type: FC<MainMenuItemProps>;
-          } | undefined;
-
-          if (!menuItem) {
-            return innerRet;
-          }
-
-          // 创建新菜单项
-          const newItem = (
-            <MenuItemWrapper
-              key="decky-music"
-              route={ROUTE_PATH}
-              label="音乐"
-              onFocus={menuItem.props.onFocus}
-              useIconAsProp={!!menuItem.props.icon}
-              MenuItemComponent={menuItem.type}
-            />
-          );
-
-          // 获取有效菜单项索引
-          const itemIndexes = menuItems
-            .map((item, index) => (item?.$$typeof && item.type !== 'div' ? index : -1))
-            .filter((idx) => idx >= 0);
-
-          if (itemIndexes.length === 0) {
-            return innerRet;
-          }
-
-          // 插入位置：如果菜单项超过4个，插入到第4个位置后，否则插入到最后
-          const insertIndex = itemIndexes.length > 4 
-            ? itemIndexes[3] + 1 
-            : itemIndexes[itemIndexes.length - 1] + 1;
-          
-          menuItems.splice(insertIndex, 0, newItem);
-
-          return innerRet;
-        });
-        patchedInnerMenu = ret.props.children.props.children[0].type;
-      }
-
-      return ret;
-    };
-
-    // 替换原始组件
-    const restoreOriginal = () => {
-      menuNode.return.type = orig;
-      if (menuNode.return.alternate) {
-        menuNode.return.alternate.type = orig;
-      }
-    };
-
-    menuNode.return.type = menuWrapper;
-    if (menuNode.return.alternate) {
-      menuNode.return.alternate.type = menuWrapper;
-    }
-
-    return restoreOriginal;
   } catch {
-    return null;
+    // Fall back to the DOM lookup below.
+  }
+
+  return document.getElementById("MainNavMenuContainer");
+};
+
+const navigateToMusic = (event?: Event) => {
+  event?.preventDefault();
+  event?.stopPropagation();
+
+  try {
+    Navigation.Navigate(ROUTE_PATH);
+  } catch {
+    // Steam may rebuild the menu while the click is being handled.
   }
 };
 
-/**
- * 菜单管理器 - 用于动态控制菜单的显示/隐藏
- */
+const replaceIcon = (menuItem: Element) => {
+  const oldIcon = menuItem.querySelector("svg");
+  if (!oldIcon) {
+    return;
+  }
+
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("viewBox", "0 0 512 512");
+  svg.setAttribute("fill", "none");
+
+  const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  path.setAttribute("fill", "currentColor");
+  path.setAttribute(
+    "d",
+    "M470.38 1.51L150.41 96A32 32 0 0 0 128 126.51v261.41A139 139 0 0 0 96 384c-53 0-96 28.66-96 64s43 64 96 64 96-28.66 96-64V214.32l256-75v184.61a138.4 138.4 0 0 0-32-3.93c-53 0-96 28.66-96 64s43 64 96 64 96-28.65 96-64V32a32 32 0 0 0-41.62-30.49z"
+  );
+
+  svg.appendChild(path);
+  oldIcon.replaceWith(svg);
+};
+
+const stripFocusState = (entry: Element) => {
+  entry.querySelectorAll("*").forEach((element) => {
+    element.classList.remove("gpfocus", "gpfocuswithin");
+  });
+};
+
+const setEntryLabel = (menuItem: Element) => {
+  menuItem.setAttribute("aria-label", "\u97f3\u4e50");
+  menuItem.setAttribute("tabindex", "0");
+  menuItem.removeAttribute("data-gp-focus");
+  menuItem.removeAttribute("data-gp-focus-visible");
+
+  const labelElement = Array.from(menuItem.querySelectorAll("div"))
+    .reverse()
+    .find((element) => element.textContent?.trim() === "\u8bbe\u7f6e");
+
+  if (labelElement) {
+    labelElement.textContent = "\u97f3\u4e50";
+  } else {
+    menuItem.textContent = "\u97f3\u4e50";
+  }
+};
+
+const bindNavigation = (menuItem: Element) => {
+  menuItem.addEventListener("click", navigateToMusic, true);
+  menuItem.addEventListener("mouseup", navigateToMusic, true);
+  menuItem.addEventListener(
+    "keydown",
+    (event) => {
+      const keyboardEvent = event as KeyboardEvent;
+      if (keyboardEvent.key === "Enter" || keyboardEvent.key === " ") {
+        navigateToMusic(event);
+      }
+    },
+    true
+  );
+};
+
+const installMenuEntryOnce = () => {
+  const mainMenu = findMainMenuElement();
+  if (!mainMenu || mainMenu.querySelector(`[${MENU_ENTRY_ATTR}]`)) {
+    return;
+  }
+
+  const settingsItem = mainMenu.querySelector('[role="menuitem"][aria-label="\u8bbe\u7f6e"]');
+  const settingsRow = settingsItem?.parentElement;
+  if (!settingsItem || !settingsRow?.parentElement) {
+    return;
+  }
+
+  const mediaItem = mainMenu.querySelector('[role="menuitem"][aria-label="\u5a92\u4f53"]');
+  const insertBeforeRow = mediaItem?.parentElement || settingsRow;
+
+  const entry = settingsRow.cloneNode(true) as Element;
+  entry.setAttribute(MENU_ENTRY_ATTR, "true");
+  stripFocusState(entry);
+
+  const menuItem = entry.querySelector('[role="menuitem"]') || entry;
+  setEntryLabel(menuItem);
+  replaceIcon(menuItem);
+  bindNavigation(menuItem);
+
+  insertBeforeRow.parentElement?.insertBefore(entry, insertBeforeRow);
+};
+
 export const menuManager = {
   tryEnable: () => {
-    if (isPatched) return;
-    const restore = doPatchMenu();
-    if (!restore) return;
-    unpatchFn = restore;
-    isPatched = true;
-  },
-
-  /**
-   * 启用菜单（插件加载时调用，必要时自动重试）
-   */
-  enable: () => {
-    if (isPatched) return;
-    if (retryTimerId) return;
-
-    const scheduleRetry = () => {
-      retryTimerId = setTimeout(() => {
-        retryTimerId = null;
-        menuManager.enable();
-      }, PATCH_RETRY_INTERVAL_MS);
-    };
-
-    menuManager.tryEnable();
-    if (!isPatched) {
-      scheduleRetry();
-    }
-  },
-
-  /**
-   * 禁用菜单（按需手动调用，通常仅用于特殊场景）
-   */
-  disable: () => {
-    if (retryTimerId) {
-      clearTimeout(retryTimerId);
-      retryTimerId = null;
-    }
-
-    if (!isPatched || !unpatchFn) {
-      isPatched = false;
-      unpatchFn = null;
+    if (isPatched) {
       return;
     }
 
-    unpatchFn();
-    unpatchFn = null;
+    installMenuEntryOnce();
+    intervalTimerId = setInterval(installMenuEntryOnce, INSTALL_INTERVAL_MS);
+    isPatched = true;
+  },
+
+  enable: () => {
+    menuManager.tryEnable();
+  },
+
+  disable: () => {
+    if (intervalTimerId) {
+      clearInterval(intervalTimerId);
+      intervalTimerId = null;
+    }
+
+    findMainMenuElement()
+      ?.querySelectorAll(`[${MENU_ENTRY_ATTR}]`)
+      .forEach((entry) => entry.remove());
+
     isPatched = false;
   },
 
-  /**
-   * 清理（插件卸载时调用）
-   */
   cleanup: () => {
-    if (retryTimerId) {
-      clearTimeout(retryTimerId);
-      retryTimerId = null;
-    }
-
-    if (unpatchFn) {
-      unpatchFn();
-      unpatchFn = null;
-    }
-    isPatched = false;
+    menuManager.disable();
   },
 
-  /**
-   * 检查是否已启用
-   */
-  isEnabled: () => isPatched
+  isEnabled: () => isPatched,
 };
 
-// 保持向后兼容 - 直接调用 patchMenu 等同于 enable
 export const patchMenu = () => {
   menuManager.enable();
   return () => menuManager.cleanup();

--- a/src/patches/menuPatchRuntime.ts
+++ b/src/patches/menuPatchRuntime.ts
@@ -1,0 +1,61 @@
+import type { ReactElement } from "react";
+
+export type ComponentFn = (...args: unknown[]) => unknown;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const getRenderableType = (type: unknown): unknown => {
+  if (typeof type === "function") {
+    return type;
+  }
+  if (!isRecord(type)) {
+    return null;
+  }
+
+  return type["type"] || type["render"] || null;
+};
+
+export const renderComponent = (
+  type: unknown,
+  props: unknown
+): ReactElement | null => {
+  const renderType = getRenderableType(type);
+  if (typeof renderType !== "function") {
+    return null;
+  }
+
+  return (renderType as (props: unknown, ref?: unknown) => ReactElement)(
+    props,
+    null
+  );
+};
+
+export const invokeOriginalComponent = (
+  originalFn: ComponentFn,
+  thisArg: unknown,
+  args: unknown[]
+): unknown => {
+  try {
+    return originalFn.apply(thisArg, args);
+  } catch (error) {
+    try {
+      return Reflect.construct(originalFn, args);
+    } catch {
+      console.error("[Decky Music] Failed to invoke original component:", error);
+      throw error;
+    }
+  }
+};
+
+export const patchRenderedMenu = (
+  innerRet: unknown,
+  patchInnerMenu: (innerRet: unknown) => unknown
+): unknown => {
+  try {
+    return patchInnerMenu(innerRet);
+  } catch (error) {
+    console.error("[Decky Music] Failed to patch inner menu:", error);
+    return innerRet;
+  }
+};

--- a/src/patches/menuPatchTypes.ts
+++ b/src/patches/menuPatchTypes.ts
@@ -1,0 +1,53 @@
+import type { FC, ReactElement, ReactNode } from "react";
+
+export interface MainMenuItemProps {
+  route: string;
+  label: ReactNode;
+  active?: string;
+  onFocus?: () => void;
+  onGamepadFocus?: () => void;
+  icon?: ReactElement;
+  onActivate?: () => void;
+  children?: ReactNode;
+}
+
+export interface MenuItemWrapperProps extends MainMenuItemProps {
+  MenuItemComponent: FC<MainMenuItemProps>;
+  useIconAsProp: boolean;
+}
+
+export interface MainMenuRenderElement extends ReactElement {
+  props: {
+    children?: {
+      props?: {
+        children?: Array<{
+          type?: FC<MainMenuItemProps>;
+        }>;
+      };
+    };
+  };
+}
+
+export interface PatchTarget {
+  type?: unknown;
+  props?: unknown;
+}
+
+export interface FiberNode {
+  memoizedProps?: {
+    navID?: string;
+  };
+  return?: {
+    type?: unknown;
+    alternate?: {
+      type?: unknown;
+    };
+  };
+}
+
+export interface ReactMenuItem {
+  key?: string | null;
+  props?: Partial<MainMenuItemProps>;
+  type?: FC<MainMenuItemProps> | string;
+  $$typeof?: symbol;
+}


### PR DESCRIPTION
修复steamos更新后steam主菜单音乐入口不显示的问题
测试steamos系统版本：3.7.25 
decky版本：3.2.4