### PR TITLE
docs: 补充 src 各目录 README 文档

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,15 +20,214 @@ LLM 约定：
 
 ## 项目使用的库
 
-<AGNET-TODO>
+### 前端（TypeScript / React）
+
+| 库 | 用途 |
+|---|---|
+| `@decky/api` | Decky Loader 插件 API，提供 `callable`（前后端 RPC 通信）和 `routerHook`（路由注册） |
+| `@decky/ui` | Decky Loader UI 组件库（`PanelSection`、`Spinner`、`Focusable` 等 Steam Deck 风格组件） |
+| `zustand` | 轻量级状态管理，用于 player / provider / auth / data / navigation 五个 Store |
+| `react-icons` | 图标库，提供 `FaMusic` 等图标 |
+| `tslib` | TypeScript 运行时辅助库 |
+
+开发依赖：
+
+| 库 | 用途 |
+|---|---|
+| `@decky/rollup` | Decky 插件专用 Rollup 打包配置 |
+| `rollup` | 前端模块打包工具 |
+| `typescript` | TypeScript 编译器（strict 模式） |
+| `eslint` + `@typescript-eslint/*` | 代码静态检查 |
+| `eslint-plugin-react` / `eslint-plugin-react-hooks` | React 规则检查 |
+| `prettier` | 代码格式化 |
+
+### 后端（Python 3.11）
+
+| 库 | 用途 |
+|---|---|
+| `qqmusic-api-python` | QQ 音乐 API 封装（来自 GitHub `L-1124/QQMusicApi` v0.4.1） |
+| `pyncm` | 网易云音乐 API 封装 |
+| `qrcode[pil]` | 二维码生成（用于扫码登录） |
+| `requests` | HTTP 请求库（用于更新检查、文件下载等） |
+| `decky`（运行时注入） | Decky Loader 提供的插件运行时 SDK（日志、路径等） |
+
+开发依赖：
+
+| 库 | 用途 |
+|---|---|
+| `ruff` | Python linter 与 formatter |
+| `pyright`（通过 pyproject.toml 配置） | Python 静态类型检查 |
+| `uv` | Python 包管理器，用于开发环境依赖安装 |
 
 ## 开发可用命令
 
-<AGNET-TODO>
+### 前端（pnpm）
+
+| 命令 | 说明 |
+|---|---|
+| `pnpm build` | 使用 Rollup 构建前端产物到 `dist/` |
+| `pnpm watch` | Rollup 监听模式，文件变更自动重新构建 |
+| `pnpm lint` | ESLint 检查 `src/` 下的 TypeScript 代码 |
+| `pnpm lint:fix` | ESLint 自动修复 |
+| `pnpm lint:py` | Ruff 检查 Python 代码 |
+| `pnpm lint:py:fix` | Ruff 自动修复并格式化 Python 代码 |
+| `pnpm typecheck` | TypeScript 类型检查（`tsc --noEmit`） |
+| `pnpm format` | Prettier 格式化 `src/` 下的代码 |
+| `pnpm format:check` | Prettier 格式检查（不修改文件） |
+| `pnpm test` | 运行类型检查（等同于 `pnpm typecheck`） |
+
+### 构建与部署（mise）
+
+| 命令 | 说明 |
+|---|---|
+| `mise run clean` | 清理构建产物（`out/`、`dist/`） |
+| `mise run build` | Docker 多阶段构建，输出打包产物到 `out/` |
+| `mise run deploy` | 通过 SSH + rsync 将插件同步到 Steam Deck 并重启 plugin_loader 服务 |
+| `mise run dev` | 一键构建 + 部署到 Steam Deck |
+| `mise run py-deps` | 安装 Python 开发依赖（`uv sync --all-extras`），用于本地 LSP 支持 |
+
+### Python（uv）
+
+| 命令 | 说明 |
+|---|---|
+| `uv sync --all-extras` | 安装全部 Python 依赖（含开发依赖），创建 `.venv` 虚拟环境 |
 
 ## 项目目录架构
 
-<AGNET-TODO>
+```
+.
+├── main.py                     # 插件后端入口，定义 Plugin 类，暴露前端可调用的 RPC 方法
+├── plugin.json                 # Decky Loader 插件元数据（名称、版本、标签）
+├── package.json                # 前端依赖与脚本定义
+├── pyproject.toml              # Python 项目配置（依赖、ruff、pyright）
+├── requirements.txt            # Python 生产依赖（Docker 构建用）
+├── Dockerfile                  # 多阶段 Docker 构建（Python 依赖 → 前端构建 → 打包）
+├── rollup.config.ts            # Rollup 打包配置
+├── tsconfig.json               # TypeScript 编译配置（strict 模式）
+├── eslint.config.ts            # ESLint 扁平配置
+├── .mise.toml                  # mise 任务定义（clean/build/deploy/dev）
+├── decky.pyi                   # Decky 运行时 Python 类型存根
+│
+├── backend/                    # Python 后端
+│   ├── __init__.py             # 统一导出后端模块
+│   ├── types.py                # 后端类型定义（TypedDict，与前端接口对齐）
+│   ├── config_manager.py       # 配置管理器（前端设置持久化、Provider 配置）
+│   ├── lyric_parser.py         # 歌词解析器（支持 LRC 和 QRC 格式）
+│   ├── update_checker.py       # 插件版本更新检查与下载
+│   ├── util.py                 # 工具函数（HTTP 请求、版本号处理、装饰器）
+│   ├── test_lyric_parser.py    # 歌词解析器单元测试
+│   └── providers/              # 音乐服务提供者
+│       ├── __init__.py         # 导出 Provider 相关类
+│       ├── base.py             # Provider 抽象基类，定义统一接口和能力枚举
+│       ├── manager.py          # Provider 管理器（注册、切换、fallback 匹配）
+│       ├── qqmusic.py          # QQ 音乐 Provider 实现
+│       ├── netease.py          # 网易云音乐 Provider 实现
+│       ├── netease_batch.py    # 网易云批量接口优化
+│       └── fallback_matcher.py # 跨 Provider 歌曲匹配（名称 + 歌手模糊匹配）
+│
+├── src/                        # TypeScript 前端
+│   ├── index.tsx               # 插件前端入口，注册 Decky 插件、路由和菜单 patch
+│   │
+│   ├── api/                    # 后端 RPC 调用封装
+│   │   └── index.ts            # 使用 @decky/api 的 callable 封装所有后端方法
+│   │
+│   ├── types/                  # 全局类型定义
+│   │   ├── index.ts            # 统一导出
+│   │   ├── api.ts              # API 响应类型（与后端 types.py 对齐）
+│   │   ├── player.ts           # 播放器相关类型（SongInfo、PlaylistInfo、ParsedLyric 等）
+│   │   ├── provider.ts         # Provider 相关类型（Capability、ProviderInfo）
+│   │   ├── navigation.ts       # 导航路由类型与常量
+│   │   └── decky-rollup.d.ts   # Decky Rollup 类型声明
+│   │
+│   ├── stores/                 # Zustand 状态管理
+│   │   ├── index.ts            # 统一导出
+│   │   ├── playerStore.ts      # 播放器状态（当前歌曲、播放列表、播放模式、音量）
+│   │   ├── providerStore.ts    # Provider 状态（当前 Provider、Provider 列表）
+│   │   ├── authStore.ts        # 认证状态（登录状态、二维码）
+│   │   ├── dataStore.ts        # 数据状态（推荐歌曲、热搜、歌单）
+│   │   └── navigationStore.ts  # 导航状态（当前页面、页面历史）
+│   │
+│   ├── features/               # 业务功能模块
+│   │   ├── index.ts            # 统一导出
+│   │   ├── auth/               # 认证功能（二维码登录流程）
+│   │   │   ├── index.ts
+│   │   │   └── hooks/useAuth.ts
+│   │   ├── data/               # 数据加载功能（推荐、热搜、歌单等数据获取）
+│   │   │   ├── index.ts
+│   │   │   └── services/       # dataLoaders.ts, imagePreloader.ts
+│   │   │   └── hooks/useDataManager.ts
+│   │   └── player/             # 播放器核心功能
+│   │       ├── index.ts
+│   │       ├── hooks/          # usePlayer.ts, useAudioTime.ts, usePlayerEffects.ts
+│   │       └── services/       # audioService.ts, lyricService.ts, playbackService.ts,
+│   │                           # queueService.ts, shuffleService.ts, persistenceService.ts
+│   │
+│   ├── components/             # UI 组件
+│   │   ├── index.ts            # 统一导出
+│   │   ├── common/             # 通用组件（BackButton, EmptyState, ErrorBoundary, LoadingSpinner, SafeImage）
+│   │   ├── layout/             # 布局组件（FocusableList, PlayAllButton）
+│   │   ├── player/             # 迷你播放器条（PlayerBar）
+│   │   ├── sidebar-player/     # 侧边栏播放器（含控制、封面、歌词、进度条、音量等子组件和 hooks）
+│   │   ├── song/               # 歌曲相关组件（SongItem, SongList, GuessLikeSection）
+│   │   ├── search/             # 搜索结果项组件
+│   │   └── settings/           # 设置页组件（AboutSection, QualitySelector, UpdateSection）
+│   │
+│   ├── pages/                  # 页面组件
+│   │   ├── index.ts            # 统一导出
+│   │   ├── sidebar/            # 侧边栏页面
+│   │   │   ├── HomePage.tsx        # 首页（推荐歌曲、猜你喜欢）
+│   │   │   ├── SearchPage.tsx      # 搜索页
+│   │   │   ├── PlayerPage.tsx      # 播放器页
+│   │   │   ├── LoginPage.tsx       # 登录页（二维码扫码）
+│   │   │   ├── PlaylistsPage.tsx   # 歌单列表页
+│   │   │   ├── PlaylistDetailPage.tsx # 歌单详情页
+│   │   │   ├── HistoryPage.tsx     # 播放历史页
+│   │   │   ├── SettingsPage.tsx    # 设置页
+│   │   │   └── ProviderSettingsPage.tsx # Provider 设置页
+│   │   └── fullscreen/         # 全屏播放器页面
+│   │       ├── PlayerPage.tsx      # 全屏播放器主页
+│   │       ├── GuessLikePage.tsx   # 猜你喜欢全屏页
+│   │       ├── KaraokeLyrics.tsx   # 卡拉 OK 歌词展示
+│   │       ├── LyricLine.tsx       # 歌词行组件
+│   │       ├── PlayerCover.tsx     # 全屏封面
+│   │       ├── PlayerMeta.tsx      # 歌曲元信息展示
+│   │       ├── PlayerProgress.tsx  # 全屏进度条
+│   │       ├── NavBar.tsx          # 全屏导航栏
+│   │       └── hooks/             # 全屏播放器 hooks
+│   │
+│   ├── navigation/             # 路由与导航
+│   │   ├── index.ts            # 统一导出
+│   │   ├── routes.ts           # 路由常量定义
+│   │   ├── Router.tsx          # 路由组件（根据当前页面渲染对应 Page）
+│   │   └── useNavigation.ts    # 导航 hook
+│   │
+│   ├── hooks/                  # 全局通用 hooks
+│   │   ├── useAppLogicNew.ts   # 应用主逻辑 hook（整合 player/nav/data）
+│   │   ├── useAutoLoadGuessLike.ts # 自动加载猜你喜欢
+│   │   ├── useDebounce.ts      # 防抖 hook
+│   │   ├── useMountedRef.ts    # 组件挂载状态引用
+│   │   ├── useProvider.ts      # Provider 相关逻辑
+│   │   ├── useQrStatusPolling.ts # 二维码状态轮询
+│   │   ├── useSearchHistory.ts # 搜索历史管理
+│   │   ├── useSteamInput.ts    # Steam Deck 输入适配
+│   │   └── useVirtualList.ts   # 虚拟列表（长列表性能优化）
+│   │
+│   ├── patches/                # Steam 客户端菜单 patch
+│   │   ├── index.ts
+│   │   └── menuPatch.tsx       # 注入快捷菜单项（全屏播放器入口）
+│   │
+│   └── utils/                  # 工具函数
+│       ├── boundedSet.ts       # 有界集合（限制大小的 Set）
+│       ├── format.ts           # 格式化工具（时间、文件大小等）
+│       ├── inputManager.ts     # 输入管理器
+│       ├── logger.ts           # 前端日志（转发到后端）
+│       ├── promise.ts          # Promise 工具函数
+│       └── styles.ts           # 样式工具
+│
+├── assets/                     # 静态资源（插件图标与 logo）
+├── docs/                       # 文档（调研计划、性能评审记录等）
+└── .github/                    # GitHub 配置（dependabot）
+```
 
 ## commit 消息生成规范
 

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1,0 +1,101 @@
+# api - 后端 RPC 调用封装
+
+## 目录介绍
+
+封装所有前端与 Python 后端之间的通信，使用 `@decky/api` 的 `callable` 函数将后端 `Plugin` 类的方法映射为前端可调用的异步函数。
+
+## 结构说明
+
+```
+api/
+└── index.ts    # 所有 RPC 方法的统一定义与导出
+```
+
+单文件模块，按功能分区组织：登录、搜索、播放、推荐、歌单、设置、更新、Provider、日志。
+
+## 业务逻辑
+
+本模块是纯粹的通信层，不包含业务逻辑。每个导出函数通过 `callable<[参数类型], 返回类型>("后端方法名")` 定义，调用时自动序列化参数并反序列化返回值。
+
+## 对外暴露的接口
+
+### 登录相关
+
+| 函数 | 说明 |
+|---|---|
+| `getQrCode(loginType)` | 获取登录二维码 |
+| `checkQrStatus()` | 检查二维码扫描状态 |
+| `logout()` | 退出登录 |
+
+### 搜索相关
+
+| 函数 | 说明 |
+|---|---|
+| `searchSongs(keyword, page, num)` | 搜索歌曲 |
+| `getHotSearch()` | 获取热门搜索 |
+| `getSearchSuggest(keyword)` | 获取搜索建议 |
+
+### 播放相关
+
+| 函数 | 说明 |
+|---|---|
+| `getSongUrl(mid, preferredQuality?, songName?, singer?)` | 获取歌曲播放 URL |
+| `getSongLyric(mid, qrc?, songName?, singer?)` | 获取歌词（已解析） |
+
+### 推荐相关
+
+| 函数 | 说明 |
+|---|---|
+| `getGuessLike()` | 获取猜你喜欢 |
+| `getDailyRecommend()` | 获取每日推荐 |
+| `getRecommendPlaylists()` | 获取推荐歌单 |
+| `getFavSongs(page, num)` | 获取收藏歌曲 |
+
+### 歌单相关
+
+| 函数 | 说明 |
+|---|---|
+| `getUserPlaylists()` | 获取用户歌单（创建的和收藏的） |
+| `getPlaylistSongs(playlistId, dirid)` | 获取歌单中的歌曲 |
+
+### 设置相关
+
+| 函数 | 说明 |
+|---|---|
+| `getFrontendSettings()` / `saveFrontendSettings(settings)` | 前端持久化设置 |
+| `getLastProviderId()` / `setLastProviderId(id)` | 上次使用的 Provider |
+| `getMainProviderId()` / `setMainProviderId(id)` | 主 Provider |
+| `getFallbackProviderIds()` / `setFallbackProviderIds(ids)` | Fallback Provider |
+| `getPlayMode()` / `setPlayMode(mode)` | 播放模式 |
+| `getVolume()` / `setVolume(volume)` | 音量 |
+| `getPreferredQuality()` / `setPreferredQuality(quality)` | 首选音质 |
+| `getProviderQueue(providerId)` / `saveProviderQueue(...)` | Provider 队列状态 |
+| `clearAllData()` | 清除所有插件数据 |
+
+### 更新相关
+
+| 函数 | 说明 |
+|---|---|
+| `checkUpdate()` | 检查插件更新 |
+| `downloadUpdate(url, filename?)` | 下载更新包 |
+| `getPluginVersion()` | 获取本地插件版本 |
+
+### Provider 相关
+
+| 函数 | 说明 |
+|---|---|
+| `getProviderInfo()` | 获取当前 Provider 信息与能力 |
+| `listProviders()` | 列出所有可用 Provider |
+| `switchProvider(providerId)` | 切换 Provider |
+| `getProviderSelection()` | 获取当前主/Fallback Provider 配置 |
+
+### 日志
+
+| 函数 | 说明 |
+|---|---|
+| `logFromFrontend(level, message, data?)` | 前端日志转发到后端 |
+
+## 依赖关系
+
+- **依赖** `@decky/api`（`callable` 函数）、`types/`（所有请求/响应类型定义）
+- **被依赖** 几乎所有业务模块：`features/`、`hooks/`、`pages/`、`stores/` 均通过此模块与后端通信

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -1,0 +1,88 @@
+# components - UI 组件
+
+## 目录介绍
+
+可复用的 UI 组件库，按功能分类组织。组件遵循 Steam Deck 的交互风格，使用 `@decky/ui` 提供的基础组件构建。
+
+## 结构说明
+
+```
+components/
+├── index.ts                    # 统一导出入口
+├── common/                     # 通用基础组件
+│   ├── index.ts
+│   ├── BackButton.tsx          # 返回按钮
+│   ├── EmptyState.tsx          # 空状态提示
+│   ├── ErrorBoundary.tsx       # React 错误边界
+│   ├── LoadingSpinner.tsx      # 加载动画
+│   └── SafeImage.tsx           # 安全图片（加载失败时显示占位图）
+├── layout/                     # 布局组件
+│   ├── index.ts
+│   ├── FocusableList.tsx       # 可聚焦列表容器（适配 Steam Deck 焦点导航）
+│   └── PlayAllButton.tsx       # 播放全部按钮
+├── player/                     # 迷你播放器
+│   ├── index.ts
+│   └── PlayerBar.tsx           # 底部迷你播放器条（显示歌曲信息、播放控制）
+├── sidebar-player/             # 侧边栏播放器（完整版）
+│   ├── index.ts
+│   ├── PlayerControls.tsx      # 播放控制按钮组（播放/暂停、上/下一曲、模式切换）
+│   ├── PlayerCover.tsx         # 歌曲封面展示
+│   ├── PlayerError.tsx         # 播放错误提示
+│   ├── PlayerInfo.tsx          # 歌曲信息展示（名称、歌手）
+│   ├── PlayerProgress.tsx      # 进度条（支持拖拽）
+│   ├── PlayerShortcuts.tsx     # 快捷操作按钮
+│   ├── PlayerVolume.tsx        # 音量控制条（支持拖拽）
+│   └── hooks/
+│       ├── useProgressDrag.ts  # 进度条拖拽 Hook
+│       └── useVolumeDrag.ts    # 音量条拖拽 Hook
+├── song/                       # 歌曲相关组件
+│   ├── index.ts
+│   ├── SongItem.tsx            # 歌曲列表项（封面、名称、歌手、时长）
+│   ├── SongList.tsx            # 歌曲列表容器
+│   └── GuessLikeSection.tsx    # 猜你喜欢区块
+├── search/                     # 搜索组件
+│   └── search-items.tsx        # 搜索结果项
+└── settings/                   # 设置组件
+    ├── index.ts
+    ├── AboutSection.tsx        # 关于信息区块
+    ├── QualitySelector.tsx     # 音质选择器
+    └── UpdateSection.tsx       # 更新检查区块
+```
+
+## 业务逻辑
+
+### common - 通用组件
+
+提供应用级基础设施：`ErrorBoundary` 捕获渲染异常防止白屏；`SafeImage` 处理图片加载失败自动切换占位图；`BackButton` 统一返回按钮样式。
+
+### player / sidebar-player - 播放器组件
+
+两套播放器 UI：
+- `PlayerBar`：底部迷你播放器条，在非播放器页面显示，提供基本播放控制和歌曲信息
+- `sidebar-player/`：完整播放器界面，包含封面、进度条、音量控制、快捷操作。进度条和音量条通过自定义拖拽 Hook（`useProgressDrag`、`useVolumeDrag`）实现触摸/鼠标拖拽交互
+
+### song - 歌曲组件
+
+`SongItem` 是核心复用组件，展示歌曲封面、名称、歌手和时长，支持点击播放和长按添加到队列。`SongList` 封装列表渲染逻辑。`GuessLikeSection` 展示猜你喜欢推荐区块。
+
+### settings - 设置组件
+
+`QualitySelector` 提供音质选项（自动/高品质/均衡/兼容）；`UpdateSection` 检查插件更新并支持下载；`AboutSection` 展示插件版本信息。
+
+## 对外暴露的接口
+
+从 `index.ts` 统一导出的组件：
+
+| 组件 | 说明 |
+|---|---|
+| `SafeImage` / `LoadingSpinner` / `EmptyState` / `BackButton` / `ErrorBoundary` | 通用基础组件 |
+| `SongItem` / `SongList` / `GuessLikeSection` | 歌曲相关组件 |
+| `PlayerBar` | 迷你播放器条 |
+| `FocusableList` / `PlayAllButton` | 布局组件 |
+
+同时通过 `index.ts` 重新导出 `pages/sidebar/` 的页面组件（`LoginPage`、`HomePage` 等），供需要的模块引用。
+
+## 依赖关系
+
+- **依赖** `@decky/ui`（Steam Deck 风格组件）、`react-icons`（图标）、`features/player`（`useAudioTime`、`useSyncAudioProgress`）、`stores/`（`playerStore`）、`types/`（数据模型）、`utils/`（`format`、`styles`）、`api/`（`getSongUrl` 等）
+- **被依赖** `src/index.tsx`（使用 `ErrorBoundary`、`PlayerBar`）、`pages/sidebar/`（使用歌曲组件、通用组件）、`pages/fullscreen/`（使用 `SafeImage`、`SongItem` 等）

--- a/src/features/README.md
+++ b/src/features/README.md
@@ -1,0 +1,90 @@
+# features - 业务功能模块
+
+## 目录介绍
+
+按业务领域组织的功能模块，每个模块包含 Hooks（组件接口）和 Services（纯逻辑层）。是应用的核心业务逻辑所在，位于 `stores/`（状态）和 `pages/`（UI）之间。
+
+## 结构说明
+
+```
+features/
+├── index.ts                    # 统一导出入口
+├── auth/                       # 认证功能
+│   ├── index.ts
+│   └── hooks/useAuth.ts        # 登录/登出/状态检查 Hook
+├── data/                       # 数据加载功能
+│   ├── index.ts
+│   ├── hooks/useDataManager.ts # 数据管理 Hook（订阅 Store + 暴露加载函数）
+│   └── services/
+│       ├── dataLoaders.ts      # 数据加载服务（猜你喜欢、每日推荐、歌单）
+│       └── imagePreloader.ts   # 图片预加载服务（封面批量预加载）
+└── player/                     # 播放器功能
+    ├── index.ts
+    ├── hooks/
+    │   ├── usePlayer.ts        # 播放器主 Hook
+    │   ├── useAudioTime.ts     # 音频时间 Hook（隔离高频更新）
+    │   └── usePlayerEffects.ts # 播放器副作用 Hook（设置恢复、歌词加载等）
+    └── services/
+        ├── audioService.ts     # 音频元素管理（全局 Audio 实例）
+        ├── lyricService.ts     # 歌词获取与缓存
+        ├── playbackService.ts  # 播放控制（播放、暂停、切歌、队列操作）
+        ├── queueService.ts     # 队列状态持久化与广播
+        ├── shuffleService.ts   # 随机播放算法
+        └── persistenceService.ts # 设置持久化（播放模式、音量、队列恢复）
+```
+
+## 业务逻辑
+
+### auth 模块
+
+提供认证流程管理：
+- `useAuth()` Hook：检查登录状态、登录、登出
+- `useAuthStatus()` / `setAuthLoggedIn()`：便捷访问登录状态
+
+### data 模块
+
+管理应用数据的加载与缓存：
+- **数据加载器**：`loadGuessLike`、`loadDailyRecommend`、`loadPlaylists` 均内置请求去重（Promise 复用）和缓存命中检查
+- **图片预加载**：使用 `requestIdleCallback` 分批预加载封面图，内置有界缓存（最多跟踪 1000 个 URL）避免内存泄漏
+- `useDataManager()` Hook：订阅 DataStore 并暴露所有加载函数
+
+### player 模块
+
+播放器核心，是最复杂的功能模块：
+- **usePlayer**：播放器主 Hook，整合所有播放操作。注意 `currentTime`/`duration` 已从此 Hook 移除以避免高频重渲染
+- **useAudioTime**：独立的时间 Hook，提供 `setInterval` 模式（100ms）和 `requestAnimationFrame` 模式（60fps）两种精度。还有 `useSyncAudioProgress` 直接操作 DOM 更新进度条（零 React 渲染开销）
+- **usePlayerEffects**：组合四个副作用 Hook——设置恢复、歌词加载、播放状态同步、播放结束处理
+- **playbackService**：播放控制中枢，处理播放、暂停、切歌、队列添加/移除、播放模式切换、音量调节、首选音质管理
+- **queueService**：队列状态的后端持久化和跨组件广播
+- **shuffleService**：Fisher-Yates 随机播放算法，维护历史和池
+- **audioService**：全局 Audio 实例管理，确保单例
+
+## 对外暴露的接口
+
+### 从 index.ts 统一导出
+
+| 导出 | 模块 | 说明 |
+|---|---|---|
+| `usePlayer` / `cleanupPlayer` / `getAudioCurrentTime` | player | 播放器 Hook 与清理 |
+| `UsePlayerReturn` | player | 播放器 Hook 返回值类型 |
+| `useAuth` / `useAuthStatus` / `setAuthLoggedIn` | auth | 认证 Hook 与工具函数 |
+| `UseAuthReturn` | auth | 认证 Hook 返回值类型 |
+| `useDataManager` | data | 数据管理 Hook |
+| `loadGuessLike` / `refreshGuessLike` / `fetchGuessLikeRaw` | data | 猜你喜欢加载 |
+| `loadDailyRecommend` / `loadPlaylists` | data | 其他数据加载 |
+| `clearDataCache` / `replaceGuessLikeSongs` | data | 缓存管理 |
+
+### player 模块额外导出
+
+| 导出 | 说明 |
+|---|---|
+| `useAudioTime` / `useAudioTimeRAF` / `getAudioTime` / `useSyncAudioProgress` | 音频时间（多精度） |
+| `playSong` / `playPlaylist` / `togglePlay` / `seek` / `stop` / `playNext` / `playPrev` 等 | 播放控制函数（可在非 Hook 环境调用） |
+| `restoreQueueForProvider` / `saveQueueState` / `broadcastPlayerState` | 队列持久化 |
+| `getGlobalAudio` / `cleanupAudio` / `setGlobalVolume` | 音频实例管理 |
+| `resetAllShuffleState` / `syncShuffleAfterPlaylistChange` | 随机播放状态管理 |
+
+## 依赖关系
+
+- **依赖** `api/`（后端通信）、`stores/`（状态管理）、`types/`（类型定义）、`utils/`（boundedSet）
+- **被依赖** `hooks/`（`useAppLogicNew` 使用 player/data/auth）、`pages/`（全屏播放器直接使用 player 服务）、`components/`（侧边栏播放器使用 `useAudioTime`）、`src/index.tsx`（`cleanupPlayer`）

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -1,0 +1,68 @@
+# hooks - 全局通用 Hooks
+
+## 目录介绍
+
+提供跨页面复用的 React Hooks，涵盖应用主逻辑编排、输入适配、数据加载、搜索历史等场景。
+
+## 结构说明
+
+```
+hooks/
+├── useAppLogicNew.ts       # 应用主逻辑 Hook（整合 player/nav/data）
+├── useAutoLoadGuessLike.ts # 自动加载猜你喜欢数据
+├── useDebounce.ts          # 防抖 Hook（值防抖 + 回调防抖）
+├── useMountedRef.ts        # 组件挂载状态引用
+├── useProvider.ts          # Provider 管理逻辑
+├── useQrStatusPolling.ts   # 二维码状态轮询
+├── useSearchHistory.ts     # 搜索历史管理（localStorage）
+├── useSteamInput.ts        # Steam Deck 手柄输入适配
+└── useVirtualList.ts       # 虚拟列表（长列表性能优化）
+```
+
+## 业务逻辑
+
+### useAppLogicNew
+
+应用顶层编排 Hook，是侧边栏 `Content` 组件的核心驱动。它整合了：
+- 登录状态检查与页面路由决策
+- 播放器操作代理（选歌、播放列表、队列管理）
+- 导航处理（页面跳转、登出、数据清理）
+- Steam Deck 手柄输入注册
+
+返回 `{ state, player, nav, data }` 四个对象，分别供 Router 和各页面组件使用。
+
+### useProvider
+
+Provider 管理 Hook，内置独立的 Zustand Store。自动加载当前 Provider 信息和可用 Provider 列表，提供能力检查（`hasCapability`、`hasAnyCapability`、`hasAllCapabilities`）和 Provider 切换功能。
+
+### useVirtualList
+
+轻量级虚拟列表实现（Spacer 模式），只渲染可见区域内的项 + 缓冲区。使用上下 spacer 保持正确的滚动高度，兼容 Decky UI 的焦点管理系统。
+
+### useSteamInput
+
+Steam Deck 控制器输入适配，注册手柄按键监听：X 键播放/暂停、L1/R1 上/下一曲、Y 键跳转播放器页。内置防抖处理。
+
+### useQrStatusPolling
+
+二维码登录状态轮询 Hook，每 2 秒检查一次扫码状态。支持 session 隔离、自动停止（成功/超时/拒绝），处理组件卸载时的清理。
+
+## 对外暴露的接口
+
+| Hook | 返回值 | 说明 |
+|---|---|---|
+| `useAppLogicNew()` | `{ state, player, nav, data }` | 应用主逻辑 |
+| `useAutoLoadGuessLike(enabled?)` | `void` | 自动加载猜你喜欢 |
+| `useDebounce(value, delay?)` | `T` | 值防抖 |
+| `useDebounceCallback(callback, delay?)` | `T` | 回调防抖 |
+| `useMountedRef()` | `RefObject<boolean>` | 组件挂载状态 |
+| `useProvider()` | Provider 状态与操作 | Provider 管理 |
+| `useQrStatusPolling(options)` | `{ start, stop }` | 二维码轮询 |
+| `useSearchHistory()` | `{ searchHistory, addToHistory, clearHistory }` | 搜索历史 |
+| `useSteamInput(props)` | `void` | 手柄输入注册 |
+| `useVirtualList(options)` | 虚拟列表状态与控制 | 虚拟列表 |
+
+## 依赖关系
+
+- **依赖** `api/`（后端调用）、`stores/`（状态管理）、`features/`（player/data/auth 功能模块）、`types/`（类型定义）、`utils/`（inputManager）
+- **被依赖** `pages/`（页面组件使用这些 Hook）、`src/index.tsx`（入口组件使用 `useAppLogicNew`）

--- a/src/navigation/README.md
+++ b/src/navigation/README.md
@@ -1,0 +1,49 @@
+# navigation - 路由与导航
+
+## 目录介绍
+
+管理侧边栏页面的路由映射和导航逻辑。采用简单的状态驱动路由方案：通过 `navigationStore` 中的 `currentPage` 值决定渲染哪个页面组件。
+
+## 结构说明
+
+```
+navigation/
+├── index.ts           # 统一导出入口
+├── routes.ts          # 路由常量定义
+├── Router.tsx         # 路由组件（switch-case 映射页面）
+└── useNavigation.ts   # 导航 Hook（封装页面跳转操作）
+```
+
+## 业务逻辑
+
+### routes.ts
+
+定义 `ROUTES` 常量对象，包含 9 个路由：`login`、`home`、`search`、`player`、`playlists`、`playlist-detail`、`history`、`settings`、`provider-settings`。
+
+### Router.tsx
+
+核心路由组件，接收 `currentPage`、`player`、`selectedPlaylist`、`nav`、`data` 五个 Props，根据 `currentPage` 值通过 switch-case 渲染对应的侧边栏页面组件。同时定义了两个接口：
+
+- `NavigationHandlers`：导航事件处理器（跳转、返回、登出等）
+- `DataHandlers`：数据事件处理器（选歌、选歌单、队列操作等）
+
+### useNavigation.ts
+
+导航便捷 Hook，封装 `navigationStore` 的操作为语义化函数：`goTo`、`goToLogin`、`goToHome`、`goToPlayer`、`goToPlaylistDetail`、`backToHome`、`backToPlaylists` 等。
+
+## 对外暴露的接口
+
+| 导出 | 类型 | 说明 |
+|---|---|---|
+| `ROUTES` | 常量 | 路由名称常量对象 |
+| `RouteName` / `PageType` / `FullscreenPageType` | 类型 | 路由类型定义 |
+| `Router` | 组件 | 路由渲染组件 |
+| `NavigationHandlers` | 接口 | 导航事件处理器 |
+| `DataHandlers` | 接口 | 数据事件处理器 |
+| `useNavigation` | Hook | 导航操作 Hook |
+| `UseNavigationReturn` | 类型 | useNavigation 返回值类型 |
+
+## 依赖关系
+
+- **依赖** `stores/`（`navigationStore`）、`types/`（路由类型、数据模型）、`pages/sidebar/`（各页面组件）、`features/player`（`usePlayer` 类型）
+- **被依赖** `src/index.tsx`（使用 `Router` 渲染侧边栏页面）、`hooks/useAppLogicNew`（构建 `NavigationHandlers` 和 `DataHandlers`）

--- a/src/pages/README.md
+++ b/src/pages/README.md
@@ -1,0 +1,91 @@
+# pages - 页面组件
+
+## 目录介绍
+
+应用的页面级组件，分为侧边栏页面（`sidebar/`）和全屏播放器页面（`fullscreen/`）两套 UI，分别适配 Decky Loader 侧边栏面板和 Steam Deck 全屏模式。
+
+## 结构说明
+
+```
+pages/
+├── index.ts                        # 统一导出（仅导出 FullscreenPlayer）
+├── FullscreenPlayer.tsx            # 全屏播放器主容器
+├── sidebar/                        # 侧边栏页面
+│   ├── index.ts                    # 统一导出
+│   ├── HomePage.tsx                # 首页（每日推荐、猜你喜欢）
+│   ├── SearchPage.tsx              # 搜索页（关键词搜索、热搜、搜索历史）
+│   ├── PlayerPage.tsx              # 播放器页（完整播放控制）
+│   ├── LoginPage.tsx               # 登录页（二维码扫码登录）
+│   ├── PlaylistsPage.tsx           # 歌单列表页（创建的和收藏的歌单）
+│   ├── PlaylistDetailPage.tsx      # 歌单详情页（歌单内歌曲列表）
+│   ├── HistoryPage.tsx             # 播放历史页（当前队列与用户队列）
+│   ├── SettingsPage.tsx            # 设置页（音质、更新、数据清理）
+│   ├── ProviderSettingsPage.tsx    # Provider 设置页（切换 Provider）
+│   └── useSearchRequests.ts        # 搜索请求 Hook
+└── fullscreen/                     # 全屏播放器页面
+    ├── types.ts                    # 全屏页面类型定义
+    ├── PlayerPage.tsx              # 全屏播放器主页（封面、歌词、控制）
+    ├── GuessLikePage.tsx           # 猜你喜欢全屏页
+    ├── KaraokeLyrics.tsx           # 卡拉 OK 歌词展示（逐字高亮）
+    ├── LyricLine.tsx               # 歌词行组件
+    ├── PlayerCover.tsx             # 全屏封面展示
+    ├── PlayerMeta.tsx              # 歌曲元信息
+    ├── PlayerProgress.tsx          # 全屏进度条
+    ├── NavBar.tsx                  # 全屏底部导航栏
+    ├── navItems.ts                 # 导航栏项定义
+    ├── useFullscreenContent.tsx    # 全屏内容渲染 Hook
+    ├── useFullscreenGamepad.ts     # 全屏手柄输入 Hook
+    └── useFullscreenHandlers.ts    # 全屏事件处理 Hook
+
+```
+
+## 业务逻辑
+
+### sidebar/ - 侧边栏页面
+
+运行在 Decky Loader 的侧边栏面板内，页面切换通过 `navigation/Router.tsx` 控制。
+
+- **HomePage**：展示每日推荐歌曲和猜你喜欢，提供导航入口（歌单、历史、设置）
+- **SearchPage**：搜索功能核心页面，集成搜索建议、热搜、搜索历史和搜索结果分页加载
+- **PlayerPage**：侧边栏完整播放器，使用 `sidebar-player/` 组件组合（封面、控制、进度条、音量、歌词）
+- **LoginPage**：二维码登录流程，支持 QQ 登录和微信登录，集成 `useQrStatusPolling` 轮询扫码状态
+- **PlaylistsPage** / **PlaylistDetailPage**：歌单浏览与详情，支持播放全部和添加到队列
+- **HistoryPage**：展示当前播放队列和用户添加的队列，支持播放指定曲目和从队列移除
+- **SettingsPage**：音质选择、更新检查、数据清理入口
+- **ProviderSettingsPage**：Provider 切换和登录状态管理
+
+### fullscreen/ - 全屏播放器
+
+运行在 Steam Deck 的全屏路由 `/decky-music` 下，独立于侧边栏的导航体系。
+
+- **FullscreenPlayer**：全屏模式的顶层容器，管理独立的页面状态（player、guess-like、search、playlists、playlist-detail、history），集成独立的登录检查、手柄输入和数据加载
+- **KaraokeLyrics**：核心歌词展示组件，支持 QRC 逐字高亮动画，LRC 逐行高亮回退
+- **NavBar**：底部导航栏，提供页面切换（播放器、猜你喜欢、搜索、歌单、历史）
+- **useFullscreenGamepad**：全屏模式手柄输入适配（方向键导航、X 播放暂停、L1/R1 切歌、Y 返回）
+- **useFullscreenContent**：集中管理全屏各页面的内容渲染和 ref 引用
+
+## 对外暴露的接口
+
+### 从 pages/index.ts 导出
+
+| 导出 | 说明 |
+|---|---|
+| `FullscreenPlayer` | 全屏播放器主组件 |
+
+### 从 pages/sidebar/index.ts 导出
+
+| 导出 | 说明 |
+|---|---|
+| `LoginPage` | 登录页 |
+| `HomePage` / `clearRecommendCache` | 首页及推荐缓存清理 |
+| `SearchPage` | 搜索页 |
+| `PlayerPage` | 播放器页 |
+| `PlaylistsPage` / `PlaylistDetailPage` | 歌单页 |
+| `HistoryPage` | 历史页 |
+| `SettingsPage` | 设置页 |
+| `ProviderSettingsPage` | Provider 设置页 |
+
+## 依赖关系
+
+- **依赖** `@decky/ui`（Steam Deck 组件）、`react-icons`（图标）、`api/`（后端调用）、`stores/`（状态管理）、`features/`（player/data/auth 功能）、`hooks/`（通用 Hook）、`components/`（可复用 UI 组件）、`navigation/`（路由类型）、`utils/`（格式化、样式）
+- **被依赖** `navigation/Router.tsx`（导入侧边栏页面组件）、`src/index.tsx`（导入 `FullscreenPlayer`）、`components/index.ts`（重新导出侧边栏页面组件）

--- a/src/patches/README.md
+++ b/src/patches/README.md
@@ -1,0 +1,47 @@
+# patches - Steam 客户端菜单 Patch
+
+## 目录介绍
+
+通过 Monkey Patch 方式将"音乐"菜单项注入到 Steam Deck 的主导航菜单中，实现全屏播放器的快捷入口。
+
+## 结构说明
+
+```
+patches/
+├── index.ts         # 统一导出入口
+└── menuPatch.tsx    # 菜单注入逻辑
+```
+
+## 业务逻辑
+
+### 工作原理
+
+1. 通过 `@decky/ui` 的 `getReactRoot` 和 `findInReactTree` 定位 Steam 客户端的 `MainNavMenuContainer` React 节点
+2. 使用 `afterPatch` 拦截菜单渲染，在现有菜单项列表中插入自定义的"音乐"项
+3. 新菜单项的路由路径为 `/decky-music`，由 `routerHook.addRoute` 注册的 `FullscreenPlayer` 组件响应
+
+### menuManager
+
+全局菜单管理器，提供生命周期控制：
+
+- `enable()`：启用菜单注入，若 React 树尚未就绪则自动重试（每 1 秒）
+- `disable()`：手动禁用菜单项
+- `cleanup()`：插件卸载时清理（恢复原始组件、取消重试）
+- `isEnabled()`：检查是否已启用
+
+### 兼容性处理
+
+自动检测菜单项组件是使用 `icon` prop 还是 `children` 传入图标，通过 `MenuItemWrapper` 适配两种模式。
+
+## 对外暴露的接口
+
+| 导出 | 类型 | 说明 |
+|---|---|---|
+| `ROUTE_PATH` | 常量 | 全屏播放器路由路径 `"/decky-music"` |
+| `menuManager` | 对象 | 菜单生命周期管理器 |
+| `patchMenu` | 函数 | 向后兼容的注入函数（等同于 `menuManager.enable()`） |
+
+## 依赖关系
+
+- **依赖** `@decky/ui`（`afterPatch`、`findInReactTree`、`getReactRoot`）、`react-icons`（`FaMusic` 图标）
+- **被依赖** `src/index.tsx`（插件入口调用 `menuManager.enable()` 注册菜单、`menuManager.cleanup()` 卸载清理，使用 `ROUTE_PATH` 注册路由）

--- a/src/stores/README.md
+++ b/src/stores/README.md
@@ -1,0 +1,64 @@
+# stores - Zustand 状态管理
+
+## 目录介绍
+
+使用 Zustand 实现的全局状态管理层，为整个应用提供响应式数据存储。共包含五个独立的 Store，各自管理不同领域的状态。
+
+## 结构说明
+
+```
+stores/
+├── index.ts            # 统一导出入口
+├── playerStore.ts      # 播放器状态
+├── providerStore.ts    # Provider 状态
+├── authStore.ts        # 认证状态
+├── dataStore.ts        # 数据缓存状态
+└── navigationStore.ts  # 导航状态
+```
+
+## 业务逻辑
+
+每个 Store 遵循统一模式：定义 State 接口（数据）+ Actions 接口（操作），通过 `create<State & Actions>` 创建。所有 Store 均提供 `getXxxState()` 函数用于非 React 环境下的状态读取。
+
+### playerStore
+
+管理播放器核心状态：当前歌曲、播放状态、播放列表、队列、播放模式、随机播放状态、歌词、音量、加载/错误状态等。提供 `reset()` 方法重置为初始状态。
+
+### providerStore
+
+管理当前活跃的音乐 Provider 信息：Provider 基本信息、能力列表、所有可用 Provider 列表。
+
+### authStore
+
+管理用户登录状态。提供 `useAuthStatus()` 便捷 Hook 和 `setAuthLoggedIn()` 非 React 环境工具函数。
+
+### dataStore
+
+管理数据缓存：猜你喜欢、每日推荐、用户歌单（创建的和收藏的）。每类数据独立跟踪 loaded 和 loading 状态，支持 `clearAll()` 一键清空。
+
+### navigationStore
+
+管理导航状态：当前页面和选中的歌单。初始页面为 `"loading"`。
+
+## 对外暴露的接口
+
+| 导出 | 类型 | 说明 |
+|---|---|---|
+| `usePlayerStore` | Hook | 播放器状态 Store |
+| `getPlayerState()` | 函数 | 获取播放器状态快照 |
+| `useProviderStore` | Hook | Provider 状态 Store |
+| `getProviderState()` | 函数 | 获取 Provider 状态快照 |
+| `useAuthStore` | Hook | 认证状态 Store |
+| `useAuthStatus()` | Hook | 获取当前登录状态 |
+| `setAuthLoggedIn(value)` | 函数 | 设置登录状态（非 React 环境） |
+| `useDataStore` | Hook | 数据缓存 Store |
+| `getDataState()` | 函数 | 获取数据缓存快照 |
+| `useNavigationStore` | Hook | 导航状态 Store |
+| `getNavigationState()` | 函数 | 获取导航状态快照 |
+
+所有 Store 同时导出 `PlayerState`、`PlayerActions`、`ProviderState`、`ProviderActions`、`AuthState`、`AuthActions`、`DataState`、`DataActions`、`NavigationState`、`NavigationActions` 类型。
+
+## 依赖关系
+
+- **依赖** `zustand`、`types/`（数据模型类型）
+- **被依赖** `features/`（服务层直接操作 Store）、`hooks/`（应用逻辑 Hook）、`pages/`（页面组件订阅状态）、`components/`（UI 组件订阅状态）

--- a/src/types/README.md
+++ b/src/types/README.md
@@ -1,0 +1,60 @@
+# types - 全局类型定义
+
+## 目录介绍
+
+集中定义前端所有 TypeScript 类型，包括播放器数据模型、Provider 能力模型、导航路由常量和 API 响应结构。所有类型与后端 `backend/types.py` 保持对齐。
+
+## 结构说明
+
+```
+types/
+├── index.ts            # 统一导出入口
+├── api.ts              # API 响应类型定义
+├── player.ts           # 播放器相关类型（歌曲、歌单、歌词、队列）
+├── provider.ts         # Provider 相关类型（能力枚举、Provider 信息）
+├── navigation.ts       # 导航路由类型与常量
+└── decky-rollup.d.ts   # Decky Rollup 模块声明
+```
+
+## 接口定义说明
+
+### player.ts - 播放器数据模型
+
+| 类型 | 说明 |
+|---|---|
+| `SongInfo` | 歌曲信息（id、mid、名称、歌手、专辑、时长、封面、provider） |
+| `PlaylistInfo` | 歌单信息（id、名称、封面、歌曲数、播放数、创建者） |
+| `PlayMode` | 播放模式：`"order"` / `"single"` / `"shuffle"` |
+| `LyricLine` | LRC 格式歌词行（时间 + 文本 + 翻译） |
+| `LyricWord` | QRC 逐字信息（文本 + 开始时间 + 持续时间） |
+| `QrcLyricLine` | QRC 格式歌词行（逐字数组 + 翻译） |
+| `ParsedLyric` | 解析后的歌词（LRC 行 + 可选 QRC 行 + 格式标识） |
+| `PlayerState` | 播放器状态（当前歌曲、播放状态、时间、音量） |
+| `StoredQueueState` | 持久化队列状态（播放列表、索引、当前 mid） |
+| `PreferredQuality` | 首选音质：`"auto"` / `"high"` / `"balanced"` / `"compat"` |
+| `FrontendSettings` | 前端持久化设置（队列、Provider、播放模式、音量、音质） |
+
+### provider.ts - Provider 能力模型
+
+| 类型 | 说明 |
+|---|---|
+| `Capability` | Provider 能力联合类型，覆盖认证、搜索、播放、歌词、推荐、歌单六大类 |
+| `ProviderBasicInfo` | Provider 基本信息（id、name） |
+| `ProviderFullInfo` | Provider 完整信息（基本信息 + 能力列表） |
+
+### navigation.ts - 导航路由
+
+| 类型 | 说明 |
+|---|---|
+| `ROUTES` | 路由常量对象（login、home、search、player 等 9 个路由） |
+| `RouteName` / `PageType` | 路由名称类型 |
+| `FullscreenPageType` | 全屏播放器页面类型：`"player"` / `"guess-like"` |
+
+### api.ts - API 响应结构
+
+为每个后端 RPC 方法定义对应的响应接口，包括：登录（`QrCodeResponse`、`QrStatusResponse`）、搜索（`SearchResponse`、`HotSearchResponse`）、播放（`SongUrlResponse`、`SongLyricResponse`）、推荐、歌单、Provider、设置、更新等共 30+ 个响应类型。
+
+## 依赖关系
+
+- **无外部依赖**，纯类型定义模块
+- **被依赖** 项目中几乎所有模块均依赖此目录的类型定义

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -1,0 +1,77 @@
+# utils - 工具函数
+
+## 目录介绍
+
+提供跨模块复用的纯工具函数，涵盖格式化、数据结构、日志、输入管理和样式常量。
+
+## 结构说明
+
+```
+utils/
+├── boundedSet.ts     # 有界 Set（自动淘汰最旧元素）
+├── format.ts         # 格式化工具（时间、播放次数、封面 URL）
+├── inputManager.ts   # 输入源管理器（侧边栏/全屏切换）
+├── logger.ts         # 前端日志（转发到后端日志系统）
+├── promise.ts        # Promise 工具函数（超时包装）
+└── styles.ts         # 样式常量（文本、布局、颜色）
+```
+
+## 对外暴露的接口
+
+### boundedSet.ts
+
+| 函数 | 说明 |
+|---|---|
+| `addToBoundedSet(cache, value, maxSize)` | 向 Set 添加元素，超过 maxSize 时自动删除最旧的元素 |
+
+用于图片预加载缓存等场景，防止全局 Set 无限增长导致内存泄漏。
+
+### format.ts
+
+| 函数 | 说明 |
+|---|---|
+| `formatDuration(seconds)` | 格式化秒数为 `mm:ss` 格式 |
+| `formatPlayCount(count)` | 格式化播放次数（万/亿） |
+| `getAlbumCover(albumMid, size?)` | 生成 QQ 音乐专辑封面 URL |
+| `getDefaultCover(size?)` | 生成默认封面占位 SVG（data URI） |
+
+### inputManager.ts
+
+| 函数 | 说明 |
+|---|---|
+| `setActiveInputSource(source)` | 设置当前活跃输入源（`"sidebar"` / `"fullscreen"` / `null`） |
+| `getActiveInputSource()` | 获取当前活跃输入源 |
+| `isInputSourceActive(source)` | 检查指定输入源是否活跃 |
+
+用于协调侧边栏和全屏播放器之间的手柄输入争用。
+
+### logger.ts
+
+| 对象 | 说明 |
+|---|---|
+| `logger.info(message, data?)` | 信息日志 |
+| `logger.warn(message, data?)` | 警告日志 |
+| `logger.error(message, data?)` | 错误日志 |
+| `logger.debug(message, data?)` | 调试日志 |
+
+通过 `api/logFromFrontend` 将前端日志转发到后端日志系统，方便在 Decky Loader 日志中统一查看。
+
+### promise.ts
+
+| 函数 | 说明 |
+|---|---|
+| `withTimeout(promise, timeoutMs)` | Promise 超时包装，超时后 reject `"TIMEOUT"` |
+
+### styles.ts
+
+| 导出 | 说明 |
+|---|---|
+| `TEXT_ELLIPSIS` / `TEXT_ELLIPSIS_2_LINES` | 文本溢出省略样式 |
+| `FLEX_CENTER` / `FLEX_CENTER_HORIZONTAL` | 居中布局样式 |
+| `COLORS` | 颜色常量（主色、文本、背景、边框、错误） |
+| `TEXT_CONTAINER` / `TEXT_CONTAINER_ELLIPSIS` | 文本容器样式 |
+
+## 依赖关系
+
+- **依赖** `api/`（`logger.ts` 使用 `logFromFrontend`）
+- **被依赖** `features/data/`（`boundedSet`、`format` 用于图片预加载）、`hooks/`（`inputManager` 用于 `useSteamInput`）、`components/`（`format`、`styles` 用于 UI 渲染）、`pages/`（`format`、`styles` 用于页面布局）


### PR DESCRIPTION
## 概述

补充 AGENTS.md 中三个 `<AGNET-TODO>` 占位符，并为 src 下的全部 11 个目录创建 README 文档。

## 变更内容

### AGENTS.md

- 填充「项目使用的库」：前端（TypeScript/React）和后端（Python 3.11）的生产依赖及开发依赖表
- 填充「开发可用命令」：pnpm、mise、uv 三套命令系统的完整说明
- 填充「项目目录架构」：从根目录到 src/ 各子目录的完整树形结构，附带每个文件/目录的用途说明

### src 各目录 README.md

为以下 11 个目录新增 README 文档，每个文档包含：

- **目录介绍**：模块功能和定位
- **结构说明**：子目录和文件清单
- **业务逻辑**：核心实现和设计要点
- **对外暴露的接口**：导出的函数、Hook、组件或类型
- **依赖关系**：模块间的上下游依赖

创建的文档：

- `api/`：后端 RPC 调用封装
- `components/`：UI 组件库
- `features/`：业务功能模块（auth、data、player）
- `hooks/`：全局通用 Hooks
- `navigation/`：路由与导航
- `pages/`：侧边栏和全屏页面
- `patches/`：Steam 客户端菜单 Patch
- `stores/`：Zustand 状态管理
- `types/`：全局类型定义
- `utils/`：工具函数

## 效果

- 完整的项目配置和命令文档，便于新贡献者快速上手
- 每个源代码目录都有清晰的模块说明，方便理解代码结构和依赖关系
- 降低代码阅读成本，提高协作效率