### PR TITLE
修掉 v1.0.0 真机验证时发现的三处收尾问题

### DIFF
--- a/.claude/skills/decky-dev/SKILL.md
+++ b/.claude/skills/decky-dev/SKILL.md
@@ -10,7 +10,8 @@ log content rules, commit rules) lives in the project's AGENTS.md and always win
 
 ## Target environment
 
-- SteamOS in a **gamescope session**, user `deck`, reachable over SSH (`DECK_HOST`, e.g. `deck@192.168.0.18`).
+- SteamOS in a **gamescope session**, user `deck`, reachable over SSH (`DECK_HOST=deck@<ip>` — no
+  default; a hardcoded one goes stale and silently targets the wrong host).
 - Decky Loader = `plugin_loader` systemd unit (root). Restart to reload plugins:
   `sudo systemctl restart plugin_loader`.
 - Homebrew tree: `~/homebrew/{plugins,logs,settings,data}/<plugin name>` — directory names use
@@ -33,7 +34,7 @@ log content rules, commit rules) lives in the project's AGENTS.md and always win
 ## Deploy loop (sideload)
 
 Sideload = build → rsync the plugin subset → restart `plugin_loader`. Keep it in a repo script
-(this repo: `scripts/deploy.sh`; override target with `DECK_HOST=deck@ip`). Two rules that bite:
+(this repo: `scripts/deploy.sh`; target is required: `DECK_HOST=deck@ip`). Two rules that bite:
 
 - Deploy scripts **copy prebuilt artifacts, they don't build**. Rebuild changed binaries first,
   or you ship stale ones.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,8 +57,8 @@ pnpm install                    # 前端依赖
 pnpm build                      # 只构建前端 → dist/
 pnpm lint                       # 前端 lint:tsc --noEmit + prettier --check;pnpm format 自动格式化
 sudo ./cli/decky plugin build . # 官方 CLI 打包整个插件 → out/<name>.zip(需 Docker + sudo)
-bash scripts/deploy.sh          # 打包 + rsync 到 Steam Deck + 重启 plugin_loader
-# 覆盖目标机:DECK_HOST=deck@ip bash scripts/deploy.sh
+DECK_HOST=deck@ip bash scripts/deploy.sh  # 打包 + rsync 到 Steam Deck + 重启 plugin_loader
+# DECK_HOST 必填、无默认值(见 issue #48);远端 sudo 要口令时另加 DECK_PASS=<口令>
 # 首次会自动下载官方 CLI 到 cli/decky(gitignore 已忽略)
 
 cargo build --release -p player          # 各二进制单独构建(走 remote_binary,不进插件包)

--- a/py_modules/bridge.py
+++ b/py_modules/bridge.py
@@ -601,7 +601,21 @@ class Bridge:
 
     async def _list_cmd(self, cmd: str, key: str, limit: int = 50, extra: dict | None = None) -> dict:
         # 列表类命令统一形状:{ok, <key>: [...], error?}。首页 50 条(翻页 P6)
-        r = await self.provider.request(cmd, {"limit": limit, **(extra or {})})
+        args = {"limit": limit, **(extra or {})}
+        r = await self.provider.request(cmd, args)
+        # provider 进程没了(崩溃/被杀)时 writer 为 None,request 会立刻短路成 timeout。
+        # 浏览类命令自己不经 _ensure_provider,所以在用户回到 QAM / 重进页面(那时才有
+        # get_provider)之前,每次搜索翻页都报错 —— 看起来就是"插件坏了"。这里就地拉起
+        # 并重试一次,把它收敛成一次用户无感的重连。只在通道确实断了时重试:上游错误
+        # (无版权 / upstream_timeout 等)不该触发重开进程。
+        # 判断只在失败分支里做:成功路径不碰 self.settings —— 有测试用 Bridge.__new__()
+        # 构造、根本没跑过 start(),成功路径读 settings 会直接 AttributeError。
+        if not r.ok and getattr(self.provider, "writer", None) is None:
+            which = getattr(self, "settings", {}).get("provider")
+            if which:
+                log("bridge", "own", "info", f"{cmd}: provider gone, respawning")
+                await self._ensure_provider(which)
+                r = await self.provider.request(cmd, args)
         if r.ok:
             return {"ok": True, key: r.data.get(key, [])}
         code = r.error.code if r.error else "provider_error"

--- a/py_modules/log.py
+++ b/py_modules/log.py
@@ -6,6 +6,7 @@
 
 import logging
 import os
+import re
 
 import decky
 
@@ -23,12 +24,42 @@ def log(source: str, origin: str, level: str, msg: str):
     decky.logger.log(_LEVELS.get(level, logging.INFO), "[%s·%s] %s", source, origin, msg)
 
 
+# 每次启动必现的库级探测噪声(issue #46)。ALSA/PipeWire 枚举候选设备时逐个试探,试不通
+# 就往 stderr 打印,紧随其后 player 自己会经 socket 通道报 "audio: default audio device
+# opened" —— 也就是说这些行并非"非预期输出",却每次都占满 release 日志顶部的 WARNING,
+# 把 stderr「出现即可疑」的信号价值稀释掉。
+#
+# 降级为 debug 而不是丢弃:dev 下照样看得到,排查真实音频问题时不丢线索。
+# 有意写窄 —— 只列观测到的具体形态,不用 "ALSA lib" 前缀一刀切,否则会连真实的设备级
+# 报错一起吞掉。新形态宁可先以 warn 冒出来,再按需补进这张表。
+_STDERR_NOISE = (
+    # PipeWire/JACK 尝试连接播放端口:cannot connect player.P.1467.2:out_000 to system:playback_1
+    re.compile(r"^cannot connect \S+:out_\d+ to system:playback_\d+$"),
+    # OSS 兼容层探测:ALSA lib pcm_oss.c:404:(_snd_pcm_oss_open) Cannot open device /dev/dsp
+    re.compile(r"^ALSA lib pcm_oss\.c:\d+:\(_snd_pcm_oss_open\) Cannot open device /dev/dsp$"),
+    # dmix 插件在已被独占的设备上试探
+    re.compile(r"^ALSA lib pcm_dmix\.c:\d+:\(snd_pcm_dmix_open\) unable to open slave$"),
+    # 配置里列了本机没有的 PCM 名
+    re.compile(r"^ALSA lib pcm\.c:\d+:\(snd_pcm_open_noupdate\) Unknown PCM "),
+    re.compile(r"^ALSA lib confmisc\.c:\d+:\([\w.]+\) (Unknown|Cannot find) "),
+)
+
+
+def stderr_level(text: str) -> str:
+    """子进程 stderr 单行该记什么级别:已知库级探测噪声 → debug,其余 → warn。"""
+    return "debug" if any(p.search(text) for p in _STDERR_NOISE) else "warn"
+
+
 async def pump_stderr(source: str, stream):
-    """子进程 stderr = 非预期输出(panic / traceback / native 报错),逐行落日志兜底。"""
+    """子进程 stderr = 非预期输出(panic / traceback / native 报错),逐行落日志兜底。
+
+    已知的库级探测噪声降到 debug(见 _STDERR_NOISE),好让 release 日志里剩下的 stderr
+    行都真的值得看。
+    """
     while stream and (line := await stream.readline()):
         text = line.decode(errors="replace").rstrip()
         if text:
-            log(source, "stderr", "warn", text)
+            log(source, "stderr", stderr_level(text), text)
 
 
 def dir_size(path: str) -> int:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 # 用官方 Decky CLI 打包并部署到 Steam Deck(含侧载二进制到 bin/,开发期免发 Release)。
 # dev 与商店安装完全一致:磁盘目录 = plugin.json 的 name(即 zip 顶层目录),原样解压。
-# 覆盖默认:DECK_HOST=deck@1.2.3.4 bash scripts/deploy.sh
+# 必须指定目标机:DECK_HOST=deck@1.2.3.4 bash scripts/deploy.sh
 # deck 用户 sudo 若需密码:导出 DECK_PASS=xxx(否则假定已配 NOPASSWD)。
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-DECK_HOST="${DECK_HOST:-deck@192.168.0.18}"
+# 不设默认值(issue #48):真机地址是各人各不相同的本地配置,写死在仓库里只会过时 ——
+# 之前那个默认值指向一台早已不用的机器,不传 DECK_HOST 就静默连错主机,失败形态是连接
+# 超时,看不出根因是「脚本里的常量陈旧」。宁可直接报错要求显式指定。
+if [ -z "${DECK_HOST:-}" ]; then
+  echo "✗ 需要指定目标机:DECK_HOST=deck@<ip> bash scripts/deploy.sh" >&2
+  echo "  (可选:DECK_PASS=<口令> 用于远端 sudo;DECK_PLUGIN_PATH 覆盖插件目录)" >&2
+  exit 2
+fi
 DECK_PLUGIN_PATH="${DECK_PLUGIN_PATH:-/home/deck/homebrew/plugins}"
 # 显示名 = 磁盘目录名(与商店安装一致,可含空格)
 NAME=$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("plugin.json", "utf8")).name)')

--- a/scripts/qq-build.Dockerfile
+++ b/scripts/qq-build.Dockerfile
@@ -5,7 +5,22 @@ ENV PYBIN=/opt/python/cp311-cp311/bin
 RUN dnf install -y patchelf && dnf clean all
 # Nuitka standalone 需要静态 libpython(manylinux 默认只放归档,解开即可)
 RUN cd /opt/_internal && tar xf static-libs-for-embedding-only.tar.xz
-# 运行时依赖钉到 qq-provider/uv.lock 解析出的版本:发出的二进制必须与本地跑过测试的那份一致。
-# 不钉会让上游随时改依赖树就静默炸构建(0.7.x 去掉 tarsio 那次),且发布不可重现。
-# 升级流程:(cd qq-provider && uv lock --upgrade-package <pkg>) → 跑测试 → 同步改这里。
-RUN $PYBIN/pip install --no-cache-dir nuitka curl_cffi==0.16.0 qqmusic-api-python==0.7.1
+# 全部钉版本 —— 钉的是构建**输入**:运行时依赖对齐 qq-provider/uv.lock,发出的二进制
+# 用的就是本地跑过测试的那几个库版本。不钉的话上游随时改依赖树就静默炸构建
+# (0.7.x 去掉 tarsio 那次),或者悄悄换掉一个没人测过的库版本。
+#
+# nuitka 也必须钉(issue #47):它是编译器而非运行时依赖,但换版本一样会改二进制
+# (代码生成、standalone 布局、隐式 include 行为都可能变),浮动就等于每次发版都在赌
+# 一个没验证过的编译器。
+#
+# 注意别误解成 byte-reproducible:实测同样的 pin 重建两次,主可执行文件 sha256 仍然不同
+# (Nuitka/gcc 会把构建路径、时间戳之类嵌进产物)。所以发版时的指纹只能取自**那一次**
+# 构建的产物,不能拿「重建一遍对得上」当校验手段。
+#
+# 升级流程:
+#   运行时依赖 —— (cd qq-provider && uv lock --upgrade-package <pkg>) → 跑测试 → 同步改这里
+#   nuitka     —— 单独一次提交改版本号 → 重建 → 真机验一遍 QQ 端(登录/搜索/播放)
+RUN $PYBIN/pip install --no-cache-dir \
+      nuitka==4.1.3 \
+      curl_cffi==0.16.0 \
+      qqmusic-api-python==0.7.1

--- a/tests/test_provider_respawn_on_browse.py
+++ b/tests/test_provider_respawn_on_browse.py
@@ -1,0 +1,123 @@
+"""provider 进程没了之后,浏览类命令要能就地把它拉起来再重试一次。
+
+真机复现:kill 掉 provider 后,search_songs 之类每次都立刻返回 timeout —— 因为
+Conn.request 在 writer 为 None 时短路,而 _list_cmd 自己不经 _ensure_provider。
+用户要退出去重开 QAM / 页面(那时才有 get_provider)才能恢复,现象像"插件坏了"。
+
+这里钉住三件事:通道断了要重开并重试;上游错误不许触发重开(免得无版权的歌把
+provider 反复重启);没选 provider 时不许重开。
+
+decky 是 Decky 运行时注入的模块,测试里打桩。
+运行:python -m unittest tests.test_provider_respawn_on_browse
+"""
+
+import asyncio
+import logging
+import os
+import sys
+import types
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "py_modules"))
+
+decky_stub = types.ModuleType("decky")
+decky_stub.DECKY_PLUGIN_DIR = "/tmp"
+decky_stub.DECKY_PLUGIN_RUNTIME_DIR = "/tmp"
+decky_stub.DECKY_PLUGIN_SETTINGS_DIR = "/tmp"
+decky_stub.DECKY_PLUGIN_LOG_DIR = "/tmp"
+decky_stub.logger = logging.getLogger("test-decky")
+
+
+async def _emit(*_a, **_k):
+    pass
+
+
+decky_stub.emit = _emit
+sys.modules.setdefault("decky", decky_stub)
+
+import bridge as bridge_mod  # noqa: E402
+import protocol  # noqa: E402
+from bridge import Bridge  # noqa: E402
+
+
+def _ok(data):
+    return protocol.ChildResponse(1, True, data, None)
+
+
+def _err(code):
+    return protocol.ChildResponse(1, False, {}, protocol.ErrorBody(code, code))
+
+
+class _FakeConn:
+    """按脚本依次返回响应;writer 为 None 表示通道已断(同 Conn.request 的短路条件)。"""
+
+    def __init__(self, responses, writer=None):
+        self.responses = list(responses)
+        self.writer = writer
+        self.calls = []
+
+    async def request(self, cmd, args=None):
+        self.calls.append((cmd, args))
+        return self.responses.pop(0)
+
+
+class TestRespawnOnBrowse(unittest.TestCase):
+    def setUp(self):
+        self.b = Bridge()
+        self.b.settings = {"version": 1, "provider": "qq"}  # start() 才建,测试里直接给
+        self.ensured = []
+
+        async def fake_ensure(which):
+            self.ensured.append(which)
+            self.b.provider.writer = object()  # 重开成功 → 通道恢复
+
+        self.b._ensure_provider = fake_ensure
+        self._saved_log = bridge_mod.log
+        bridge_mod.log = lambda *_a, **_k: None
+
+    def tearDown(self):
+        bridge_mod.log = self._saved_log
+
+    def test_dead_channel_respawns_and_retries(self):
+        self.b.provider = _FakeConn([_err("timeout"), _ok({"songs": [1, 2, 3]})], writer=None)
+        out = asyncio.run(self.b._list_cmd("search_songs", "songs"))
+        self.assertEqual(self.ensured, ["qq"], "通道断了必须重开 provider")
+        self.assertEqual(out, {"ok": True, "songs": [1, 2, 3]})
+        self.assertEqual(len(self.b.provider.calls), 2, "应当重试一次")
+
+    def test_upstream_error_does_not_respawn(self):
+        """通道还在,只是上游报错 —— 不该因此重启进程。"""
+        self.b.provider = _FakeConn([_err("upstream_timeout")], writer=object())
+        out = asyncio.run(self.b._list_cmd("search_songs", "songs"))
+        self.assertEqual(self.ensured, [])
+        self.assertEqual(out, {"ok": False, "songs": [], "error": "upstream_timeout"})
+
+    def test_no_provider_selected_does_not_respawn(self):
+        self.b.settings["provider"] = None
+        self.b.provider = _FakeConn([_err("timeout")], writer=None)
+        out = asyncio.run(self.b._list_cmd("search_songs", "songs"))
+        self.assertEqual(self.ensured, [])
+        self.assertFalse(out["ok"])
+
+    def test_respawn_failing_again_reports_error_once(self):
+        """重开后仍失败:正常报错,不再无限重试。"""
+
+        async def ensure_but_still_dead(which):
+            self.ensured.append(which)
+
+        self.b._ensure_provider = ensure_but_still_dead
+        self.b.provider = _FakeConn([_err("timeout"), _err("timeout")], writer=None)
+        out = asyncio.run(self.b._list_cmd("search_songs", "songs"))
+        self.assertEqual(self.ensured, ["qq"])
+        self.assertEqual(len(self.b.provider.calls), 2)
+        self.assertEqual(out, {"ok": False, "songs": [], "error": "timeout"})
+
+    def test_success_path_untouched(self):
+        self.b.provider = _FakeConn([_ok({"songs": [7]})], writer=object())
+        out = asyncio.run(self.b._list_cmd("search_songs", "songs"))
+        self.assertEqual(self.ensured, [])
+        self.assertEqual(out, {"ok": True, "songs": [7]})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stderr_filter.py
+++ b/tests/test_stderr_filter.py
@@ -1,0 +1,110 @@
+"""子进程 stderr 的噪声分级(issue #46)。
+
+真机 v1.0.0 上 player 每次启动都会打出几行 ALSA/PipeWire 设备探测输出,紧接着
+"audio: default audio device opened" 就成功了。它们不是"非预期输出",却每次占据 release
+日志顶部的 WARNING,削弱 stderr「出现即可疑」的信号价值。
+
+这里钉住两件事:已知噪声降到 debug;**没列进表的一律仍是 warn**(过滤必须窄,不能把
+真实的设备级报错一起吞掉)。
+
+decky 是 Decky 运行时注入的模块,测试里打桩。
+运行:python -m unittest tests.test_stderr_filter
+"""
+
+import asyncio
+import logging
+import os
+import sys
+import types
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "py_modules"))
+
+decky_stub = types.ModuleType("decky")
+decky_stub.DECKY_PLUGIN_DIR = "/tmp"
+decky_stub.DECKY_PLUGIN_RUNTIME_DIR = "/tmp"
+decky_stub.DECKY_PLUGIN_SETTINGS_DIR = "/tmp"
+decky_stub.DECKY_PLUGIN_LOG_DIR = "/tmp"
+decky_stub.logger = logging.getLogger("test-decky")
+sys.modules.setdefault("decky", decky_stub)
+
+import log as log_mod  # noqa: E402
+
+# 真机 v1.0.0 日志里逐字抄下来的四行(2026-08-11 10.43.41.log)
+REAL_NOISE = [
+    "cannot connect player.P.1467.2:out_000 to system:playback_1",
+    "cannot connect player.P.1467.4:out_000 to system:playback_1",
+    "cannot connect player.P.1467.5:out_000 to system:playback_1",
+    "ALSA lib pcm_oss.c:404:(_snd_pcm_oss_open) Cannot open device /dev/dsp",
+]
+
+
+class TestStderrLevel(unittest.TestCase):
+    def test_real_device_noise_is_demoted(self):
+        for line in REAL_NOISE:
+            self.assertEqual(log_mod.stderr_level(line), "debug", line)
+
+    def test_other_known_probe_forms_are_demoted(self):
+        for line in [
+            "ALSA lib pcm_dmix.c:1032:(snd_pcm_dmix_open) unable to open slave",
+            "ALSA lib pcm.c:2722:(snd_pcm_open_noupdate) Unknown PCM cards.pcm.rear",
+            "ALSA lib confmisc.c:1369:(snd_func_refer) Unknown parameter default",
+        ]:
+            self.assertEqual(log_mod.stderr_level(line), "debug", line)
+
+    def test_real_failures_stay_warn(self):
+        """过滤写窄的意义就在这里:真出事的行必须还能冒出来。"""
+        for line in [
+            "thread 'main' panicked at src/audio.rs:42:9:",
+            "ALSA lib pcm_hw.c:1829:(snd_pcm_hw_open) open '/dev/snd/pcmC0D0p' failed: No such device",
+            "ALSA lib: could not open any audio device",
+            "Traceback (most recent call last):",
+            "cannot connect to PipeWire",  # 形似但不是端口探测那条
+            "cannot connect player.P.1467.2:out_000 to system:capture_1",  # 采集口,不在表内
+            "audio: default audio device opened",
+        ]:
+            self.assertEqual(log_mod.stderr_level(line), "warn", line)
+
+
+class _FakeStream:
+    """按行喂 bytes 的假 stderr;读完返回 b"" 表示 EOF。"""
+
+    def __init__(self, lines):
+        self._lines = list(lines)
+
+    async def readline(self):
+        return self._lines.pop(0) if self._lines else b""
+
+
+class TestPumpStderr(unittest.TestCase):
+    def setUp(self):
+        self.records = []
+        self._saved = log_mod.log
+        log_mod.log = lambda source, origin, level, msg: self.records.append((origin, level, msg))
+
+    def tearDown(self):
+        log_mod.log = self._saved
+
+    def test_mixed_stream_splits_by_level(self):
+        stream = _FakeStream(
+            [
+                b"cannot connect player.P.1.2:out_000 to system:playback_1\n",
+                b"thread 'main' panicked at src/lib.rs:1:1:\n",
+                b"\n",  # 空行不该产生记录
+                b"ALSA lib pcm_oss.c:404:(_snd_pcm_oss_open) Cannot open device /dev/dsp\n",
+            ]
+        )
+        asyncio.run(log_mod.pump_stderr("player", stream))
+
+        self.assertEqual([r[1] for r in self.records], ["debug", "warn", "debug"])
+        self.assertTrue(all(r[0] == "stderr" for r in self.records))
+        # panic 必须原样保留,不被改写
+        self.assertIn("panicked", self.records[1][2])
+
+    def test_no_stream_is_a_noop(self):
+        asyncio.run(log_mod.pump_stderr("player", None))
+        self.assertEqual(self.records, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
v1.0.0 发布后真机验证过程中记录的三个问题,逐个修掉。三个提交互不相干,可独立 review。

## Closes #46 — ALSA/PipeWire 探测噪声不该占 release 日志的 WARN

`a4df3a1`。player 每次启动都有几行设备枚举 stderr 被记成 WARNING,而紧随其后
`audio: default audio device opened` 就成功了 —— 不是「非预期输出」,却每次占满 release
日志顶部,稀释了 stderr「出现即可疑」的信号价值。

新增 `stderr_level()`:已知形态降 debug(dev 仍可见,release 过滤),**其余一律仍是 warn**。
过滤有意写窄,只列观测到的具体形态,不用 `ALSA lib` 前缀一刀切,否则会连真实的设备级
报错(如 `pcm_hw.c` open 失败)一起吞掉。

`tests/test_stderr_filter.py` 正反两向都钉:真机 v1.0.0 日志里那 4 行逐字抄下来必须降级;
panic / Traceback / 真实设备报错 / 形近但不同的行必须仍是 warn。

## Closes #47 — nuitka 也钉版本

`0c2e394`。v1.0.0 钉了运行时依赖但漏了编译器。nuitka 换版本一样会改二进制(代码生成、
standalone 布局、隐式 include 行为),浮动等于每次发版都在赌一个没验证过的编译器 ——
与 0.7.x 去掉 tarsio 那次是同一类事故。钉到构建镜像实测的 4.1.3。

顺带纠正了注释里一个会误导人的说法:**钉版本钉的是构建输入,不等于产物可重现**。实测
同 pin 重建,主可执行文件 sha256 仍不同(Nuitka/gcc 把构建路径、时间戳嵌进产物),故
发版指纹只能取自那一次构建的产物,不能拿「重建一遍对得上」当校验手段。

## Closes #48 — DECK_HOST 去掉默认值

`b19708e`。原默认值指向一台早已不用的机器,不传就静默连错主机,失败形态是连接超时,
看不出根因是脚本里的常量陈旧。改为缺失即 `exit 2` 并打印用法。顺带清掉三处会让人误以为
「有合理默认」的措辞:AGENTS.md 里单独列的 `bash scripts/deploy.sh`(现在会直接报错)、
decky-dev skill 的 "override target" 与那个陈旧示例 IP。

## 检查状态

已过:bridge 100 个单测(95 + 5 新增)、前端 tsc + prettier、
`cargo clippy --workspace --all-targets -D warnings`、4 个 Rust 测试套件、ruff;
qq-provider 用钉版本的镜像真实重建成功并冒烟通过。

`deploy.sh` 的两条路径已本地验证:不传 `DECK_HOST` → `exit 2` 且不做任何事;传了 → 通过
校验继续进构建。

**未做真机验证** —— 当前手上没有 Deck。#46 改了运行时日志行为、#47 产出了新的二进制,
两者的真机验收清单已登记在 #49,合并后仍需按那份清单验完才能算完成。